### PR TITLE
Enable test and coverage results reporting in dashboard

### DIFF
--- a/.github/azure-pipelines/ci-build.yaml
+++ b/.github/azure-pipelines/ci-build.yaml
@@ -17,3 +17,16 @@ steps:
           checkLatest: true
 
     - template: templates/build.yaml
+
+    - task: PublishTestResults@2
+      displayName: 'Collect test results'
+      condition: succeededOrFailed()
+      inputs:
+          testRunner: JUnit
+          testResultsFiles: 'reports/*.xml'
+
+    - task: PublishCodeCoverageResults@1
+      displayName: 'Collect code coverage'
+      inputs:
+          codeCoverageTool: Cobertura
+          summaryFileLocation: coverage/*.xml

--- a/.github/azure-pipelines/templates/build.yaml
+++ b/.github/azure-pipelines/templates/build.yaml
@@ -16,7 +16,7 @@ steps:
     - script: 'npm run build'
       displayName: 'Build: wiremock-captain'
 
-    - script: 'npm run test'
+    - script: 'npm run coverage'
       displayName: 'Test: wiremock-captain'
 
     - script: 'npm install'


### PR DESCRIPTION
### SUMMARY

Add test and coverage reporting to the CI dashboard.

### DETAILS

- Pipeline config updated.

### TESTING
- Check the "Details" link on the CI build below to see the in-github summary at a glance.
- Click "view more details in azure" to go to the usual dashboard results.

### SCREENSHOT
<img width="1114" alt="Screen Shot 2021-03-05 at 10 14 49 AM" src="https://user-images.githubusercontent.com/58273/110134676-a6fe0400-7d9b-11eb-84cd-030205b73c80.png">
