### PR TITLE
add feature: stateful mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,19 +119,21 @@ describe('Integration with WireMock', () => {
         it('mocks downstream service', async () => {
             const requestBody = {
                 objectKey: {
-                    intKey: 5, stringKey: 'stringKey',
+                    intKey: 5,
+                    stringKey: 'stringKey',
                 },
             };
             const testEndpoint = '/testEndpoint';
             const responseBody = { test: 'testValue' };
-            await mock.register({ method: 'POST', endpoint: testEndpoint, body: requestBody },
-                                { status: 200, body: responseBody });
+            await mock.register(
+                { method: 'POST', endpoint: testEndpoint, body: requestBody },
+                { status: 200, body: responseBody },
+            );
 
             // rest of the test
         });
     });
 });
-
 ```
 
 ## More examples
@@ -158,7 +160,12 @@ await mock.register(mockedRequest, mockedResponse, features);
 const headers = { Accept: 'json', Authorization: 'test-auth' };
 const mockedRequest: IWireMockRequest = { method: 'GET', endpoint: '/test', headers };
 const mockedResponse: IWireMockResponse = { status: 200 };
-const features: IWireMockFeatures = { requestHeaderFeature: { Accept: MatchingAttributes.EqualTo, Authorization: MatchingAttributes.DoesNotMatch } };
+const features: IWireMockFeatures = {
+    requestHeaderFeature: {
+        Accept: MatchingAttributes.EqualTo,
+        Authorization: MatchingAttributes.DoesNotMatch,
+    },
+};
 await mock.register(mockedRequest, mockedResponse, features);
 ```
 
@@ -168,7 +175,9 @@ By default, `cookies`, `headers`, and `queryParameters` use equality checks. So 
 const headers = { Accept: 'json', Authorization: 'test-auth' };
 const mockedRequest: IWireMockRequest = { method: 'GET', endpoint: '/test', headers };
 const mockedResponse: IWireMockResponse = { status: 200 };
-const features: IWireMockFeatures = { requestHeaderFeature: { Authorization: MatchingAttributes.DoesNotMatch } };
+const features: IWireMockFeatures = {
+    requestHeaderFeature: { Authorization: MatchingAttributes.DoesNotMatch },
+};
 await mock.register(mockedRequest, mockedResponse, features);
 ```
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,39 @@ await mock.register(mockedRequest, mockedResponseHighPriority, featuresHighPrior
 await mock.register(mockedRequest, mockedResponseLowPriority, featuresLowPriority);
 ```
 
+### Stateful mocks
+
+`Scenario` can be leveraged to allow stateful mocks. To do so, provide `scenario` in
+`IWireMockFeatures` while building the mock. The starting state will always be `Started`.
+Example:
+
+```typescript
+await mock.register(
+    { method: 'GET', endpoint: '/test' },
+    { status: 201 },
+    {
+        scenario: {
+            scenarioName: 'test-scenario',
+            requiredScenarioState: 'Started',
+            newScenarioState: 'test-state',
+        },
+    },
+);
+await mock.register(
+    { method: 'GET', endpoint: '/test' },
+    { status: 200 },
+    {
+        scenario: {
+            scenarioName: 'test-scenario',
+            requiredScenarioState: 'test-state',
+        },
+    },
+);
+```
+
+In the above example, the first request made will respond with status code `201` while
+the second and all subsequent requests will respond with status `200`.
+
 ### Using with jest
 Jest `expect` works well with `WireMock` and can used for various kinds of checks
 ```typescript

--- a/src/IWireMockFeatures.ts
+++ b/src/IWireMockFeatures.ts
@@ -1,6 +1,8 @@
 // Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
 // See the LICENSE file for license information.
 
+import { IWireMockScenario } from './IWireMockTypes';
+
 /**
  * Specifies all possible attributes that can be assigned to mocked request or response.
  * Be default, all matches happen on equality but this extends the functionality.
@@ -14,6 +16,10 @@ export interface IWireMockFeatures {
     requestHeaderFeatures?: Record<string, MatchingAttributes>;
     requestQueryParamFeatures?: Record<string, MatchingAttributes>;
     responseBodyType?: BodyType;
+    /**
+     * All the scenarios start from state `Started`
+     */
+    scenario?: IWireMockScenario;
     /**
      * Lower the value, higher the priority
      */

--- a/src/IWireMockTypes.ts
+++ b/src/IWireMockTypes.ts
@@ -24,3 +24,9 @@ export interface IWireMockMockedRequestResponse {
     response: IResponseMock;
     priority?: number;
 }
+
+export interface IWireMockScenario {
+    scenarioName: string;
+    requiredScenarioState: 'Started' | string;
+    newScenarioState?: string;
+}

--- a/test/unit/WireMock.spec.ts
+++ b/test/unit/WireMock.spec.ts
@@ -97,8 +97,20 @@ describe('WireMock', () => {
         });
     });
 
+    describe('getScenario', () => {
+        it('getAllScenarios', async () => {
+            const wireMock = require('../../src/WireMock');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMock.WireMock(wireMockUrl);
+            await mock.getAllScenarios();
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/scenarios', {
+                method: 'GET',
+            });
+        });
+    });
+
     describe('register', () => {
-        it('should return empty response w/ priority', async () => {
+        it('should return empty response w/ priority and scenario', async () => {
             jest.mock('../../src/RequestModel', () => ({
                 createWireMockRequest: jest.fn().mockName('mockedGetRequest'),
             }));
@@ -108,15 +120,26 @@ describe('WireMock', () => {
             const wireMock = require('../../src/WireMock');
             const wireMockUrl = 'https://testservice/';
             const mock = new wireMock.WireMock(wireMockUrl);
-            const resp = await mock.register({}, {}, { stubPriority: 1 });
+            const resp = await mock.register(
+                {},
+                {},
+                {
+                    stubPriority: 1,
+                    scenario: { scenarioName: 'test-scenario', requiredScenarioState: 'Started' },
+                },
+            );
             expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
                 method: 'POST',
                 body: expect.stringContaining('priority'),
             });
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
+                method: 'POST',
+                body: expect.stringContaining('scenario'),
+            });
             expect(resp).toEqual({});
         });
 
-        it('should return empty response w/o priority', async () => {
+        it('should return empty response w/o priority and scenario', async () => {
             jest.mock('../../src/RequestModel', () => ({
                 createWireMockRequest: jest.fn().mockName('mockedGetRequest'),
             }));
@@ -128,6 +151,21 @@ describe('WireMock', () => {
             const mock = new wireMock.WireMock(wireMockUrl);
             const resp = await mock.register({}, {});
             expect(resp).toEqual({});
+        });
+    });
+
+    describe('resetScenario', () => {
+        it('resetAllScenarios', async () => {
+            const wireMock = require('../../src/WireMock');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMock.WireMock(wireMockUrl);
+            await mock.resetAllScenarios();
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(
+                wireMockUrl + '__admin/scenarios/reset',
+                {
+                    method: 'POST',
+                },
+            );
         });
     });
 


### PR DESCRIPTION
### SUMMARY

add support for wiremock `scenario` to allow for stateful mocking

### DETAILS

- support creation of stateful mocks
- support getting all scenarios and resetting them

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
