### PR TITLE
feat: add WireMockAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ docker run -itd --rm --name wiremock-container -p 8080:8080 rodolpheche/wiremock
 Typical usage looks like this:
 
 ```typescript
-// Import the package
 import { WireMock } from 'wiremock-captain';
 
 describe('Integration with WireMock', () => {
@@ -128,10 +127,46 @@ describe('Integration with WireMock', () => {
                     stringKey: 'stringKey',
                 },
             };
-            const testEndpoint = '/testEndpoint';
+            const testEndpoint = '/test-endpoint';
             const responseBody = { test: 'testValue' };
             await mock.register(
                 { method: 'POST', endpoint: testEndpoint, body: requestBody },
+                { status: 200, body: responseBody },
+            );
+
+            // rest of the test
+        });
+    });
+});
+```
+
+If the purpose is to only mock a single API over and over, `WireMockAPI` would be the better option.
+Usage would look like:
+```typescript
+import { WireMockAPI } from 'wiremock-captain';
+
+describe('Integration with WireMock', () => {
+    // Connect to WireMock
+    const downstreamWireMockUrl = 'http://localhost:8080';
+    const downstreamWireMockEndpoint = '/test-endpoint';
+    const downstreamWireMockMethod = 'POST';
+    const mock = new WireMockAPI(downstreamWireMockUrl, downstreamWireMockEndpoint, downstreamWireMockMethod);
+
+    afterAll(async () => {
+        await mock.clearAll();
+    });
+
+    describe('happy path', () => {
+        it('mocks downstream service', async () => {
+            const requestBody = {
+                objectKey: {
+                    intKey: 5,
+                    stringKey: 'stringKey',
+                },
+            };
+            const responseBody = { test: 'testValue' };
+            await mock.register(
+                { body: requestBody },
                 { status: 200, body: responseBody },
             );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6885,9 +6885,9 @@
             }
         },
         "tar": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-            "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.5.tgz",
+            "integrity": "sha512-FiK6MQyyaqd5vHuUjbg/NpO8BuEGeSXcmlH7Pt/JkugWS8s0w8nKybWjHDJiwzCAIKZ66uof4ghm4tBADjcqRA==",
             "dev": true,
             "requires": {
                 "chownr": "^2.0.0",

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -2,15 +2,15 @@
 // See the LICENSE file for license information.
 
 import fetch, { Response } from 'node-fetch';
-import { IWireMockFeatures } from './IWireMockFeatures';
-import { IWireMockRequest } from './IWireMockRequest';
-import { IWireMockResponse } from './IWireMockResponse';
 import {
     IRequestMock,
     IResponseMock,
+    IWireMockRequest,
+    IWireMockResponse,
+    IWireMockFeatures,
     IWireMockMockedRequestResponse,
     Method,
-} from './IWireMockTypes';
+} from '.';
 import { createWireMockRequest } from './RequestModel';
 import { createWireMockResponse } from './ResponseModel';
 
@@ -22,7 +22,7 @@ const WIREMOCK_REQUESTS_URL = '__admin/requests';
 const WIREMOCK_SCENARIO_URL = '__admin/scenarios';
 
 export class WireMock {
-    private readonly baseUrl: string;
+    protected readonly baseUrl: string;
 
     public constructor(baseUrl: string) {
         this.baseUrl = baseUrl;
@@ -182,7 +182,7 @@ export class WireMock {
         });
     }
 
-    private makeUrl(endpoint: string) {
+    protected makeUrl(endpoint: string) {
         return new URL(endpoint, this.baseUrl).href;
     }
 }

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -144,7 +144,7 @@ export class WireMock {
     }
 
     /**
-     * Returns list of request(s) made to the WireMock instance
+     * Returns list of request(s) made to the WireMock API
      * @param method Method to match the request(s) made against
      * @param endpointUrl URL to get the request(s) made against
      * @returns List of wiremock requests made to the endpoint with given method

--- a/src/WireMockAPI.ts
+++ b/src/WireMockAPI.ts
@@ -55,7 +55,7 @@ export class WireMockAPI extends WireMock {
     }
 
     /**
-     * Returns list of request(s) made to the WireMock instance
+     * Returns list of request(s) made to the WireMock API
      * @returns List of wiremock requests made to the endpoint with given method
      */
     public async getRequestsForAPI(): Promise<unknown[]> {

--- a/src/WireMockAPI.ts
+++ b/src/WireMockAPI.ts
@@ -1,3 +1,6 @@
+// Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
+// See the LICENSE file for license information.
+
 import { IWireMockRequest, IWireMockResponse, IWireMockFeatures } from '.';
 import { IWireMockMockedRequestResponse, Method } from './IWireMockTypes';
 import { WireMock } from './WireMock';
@@ -6,7 +9,6 @@ export class WireMockAPI extends WireMock {
     protected readonly endpoint: string;
     protected readonly method: Method;
     protected readonly features?: IWireMockFeatures;
-    protected readonly contract?: any;
 
     public constructor(
         baseUrl: string,

--- a/src/WireMockAPI.ts
+++ b/src/WireMockAPI.ts
@@ -1,0 +1,56 @@
+import { IWireMockRequest, IWireMockResponse, IWireMockFeatures } from '.';
+import { IWireMockMockedRequestResponse, Method } from './IWireMockTypes';
+import { WireMock } from './WireMock';
+
+export class WireMockAPI extends WireMock {
+    protected readonly endpoint: string;
+    protected readonly method: Method;
+    protected readonly features?: IWireMockFeatures;
+    protected readonly contract?: any;
+
+    public constructor(
+        baseUrl: string,
+        endpoint: string,
+        method: Method,
+        features?: Omit<IWireMockFeatures, 'scenario' | 'stubPriority'>,
+    ) {
+        super(baseUrl);
+        this.endpoint = endpoint;
+        this.method = method;
+        this.features = features;
+    }
+
+    /**
+     * Creates a new stub with desired request and response match
+     * @param request Request object for the stub mapping
+     * @param response Response object for the stub mapping
+     * @param features Additional options to be used for creation of stub mapping
+     * @returns Created wiremock stub mapping. Contains `id` which is needed to delete a mapping
+     */
+    public async register(
+        request: Omit<IWireMockRequest, 'endpoint' | 'method'>,
+        response: IWireMockResponse,
+        features?: IWireMockFeatures,
+    ): Promise<IWireMockMockedRequestResponse> {
+        return await super.register(
+            { endpoint: this.endpoint, method: this.method, ...request },
+            response,
+            { ...this.features, ...features },
+        );
+    }
+
+    public async registerDefaultResponse(
+        response: IWireMockResponse,
+        features?: IWireMockFeatures,
+    ): Promise<IWireMockMockedRequestResponse> {
+        return await this.register({}, response, features);
+    }
+
+    /**
+     * Returns list of request(s) made to the WireMock instance
+     * @returns List of wiremock requests made to the endpoint with given method
+     */
+    public async getRequestsForAPI(): Promise<unknown[]> {
+        return await super.getRequestsForAPI(this.method, this.endpoint);
+    }
+}

--- a/src/WireMockAPI.ts
+++ b/src/WireMockAPI.ts
@@ -41,6 +41,12 @@ export class WireMockAPI extends WireMock {
         );
     }
 
+    /**
+     * Creates a new default stub with desired response
+     * @param response Response object for the stub mapping
+     * @param features Additional options to be used for creation of stub mapping
+     * @returns Created wiremock stub mapping. Contains `id` which is needed to delete a mapping
+     */
     public async registerDefaultResponse(
         response: IWireMockResponse,
         features?: IWireMockFeatures,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 // See the LICENSE file for license information.
 
 export * from './WireMock';
+export * from './WireMockAPI';
 export * from './IWireMockFeatures';
 export * from './IWireMockRequest';
 export * from './IWireMockResponse';

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -23,7 +23,7 @@ describe('Integration with WireMock', () => {
                         stringKey: 'stringKey',
                     },
                 };
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
                 await mock.register(
                     {
@@ -56,7 +56,7 @@ describe('Integration with WireMock', () => {
             });
 
             it('sets up a stub mapping in wiremock server without body', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
                 await mock.register(
                     {
@@ -84,7 +84,7 @@ describe('Integration with WireMock', () => {
                         stringKey: 'stringKey',
                     },
                 };
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
                 const mockedStub = await mock.register(
                     {
@@ -124,7 +124,7 @@ describe('Integration with WireMock', () => {
                         stringKey: 'stringKey',
                     },
                 };
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBodyLowPriority = { test: 'testValue' };
                 const responseBodyHighPriority = { test: 'biggerTestValue' };
                 await mock.register(
@@ -172,7 +172,7 @@ describe('Integration with WireMock', () => {
 
         describe('deleteMapping', () => {
             it('sets up a stub mapping and deletes it', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
 
                 expect(await mock.getAllMappings()).toHaveLength(0);
@@ -194,7 +194,7 @@ describe('Integration with WireMock', () => {
 
         describe('getMapping', () => {
             it('sets up a stub mapping and returns it with get mappings', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
 
                 expect(await mock.getAllMappings()).toHaveLength(0);
@@ -214,7 +214,7 @@ describe('Integration with WireMock', () => {
 
         describe('getRequests', () => {
             it('returns number of requests made', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
@@ -226,7 +226,7 @@ describe('Integration with WireMock', () => {
             });
 
             it('returns number of unmatched requests', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
@@ -240,7 +240,7 @@ describe('Integration with WireMock', () => {
 
         describe('getScenarios', () => {
             it('should return scenarios', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 expect(await mock.getAllScenarios()).toHaveLength(0);
                 await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 400 });
                 expect(await mock.getAllScenarios()).toHaveLength(0);
@@ -260,7 +260,7 @@ describe('Integration with WireMock', () => {
 
         describe('resetScenarios', () => {
             it('should return scenarios', async () => {
-                const testEndpoint = '/testEndpoint';
+                const testEndpoint = '/test-endpoint';
                 await mock.register(
                     { method: 'GET', endpoint: testEndpoint },
                     { status: 200 },

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -1,0 +1,271 @@
+// Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
+// See the LICENSE file for license information.
+
+import { afterAll, describe, expect, it } from '@jest/globals';
+import fetch from 'node-fetch';
+import { WireMockAPI } from '../../src';
+
+describe('Integration with WireMock', () => {
+    // tslint:disable-next-line: no-http-string
+    const wiremockUrl = 'http://localhost:8080';
+    const testEndpoint = '/testEndpoint';
+    const testMethod = 'POST';
+    const mock = new WireMockAPI(wiremockUrl, testEndpoint, testMethod);
+
+    beforeEach(async () => {
+        await mock.clearAll();
+    });
+
+    describe('WireMock', () => {
+        describe('register', () => {
+            it('sets up a stub mapping in wiremock server and expects mapping to be called', async () => {
+                const requestBody = {
+                    objectKey: {
+                        intKey: 5,
+                        stringKey: 'stringKey',
+                    },
+                };
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {
+                        body: requestBody,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                );
+
+                const response = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                    body: JSON.stringify(requestBody),
+                });
+                const body = await response.json();
+                expect(body).toEqual(responseBody);
+                const calls = await mock.getRequestsForAPI();
+
+                const jestMock = jest.fn();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                calls.forEach((request: any) => {
+                    jestMock(request.request);
+                });
+                expect(jestMock).toHaveBeenCalledWith(
+                    expect.objectContaining({ body: JSON.stringify(requestBody) }),
+                );
+            });
+
+            it('sets up a stub mapping in wiremock server without body', async () => {
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {},
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                );
+
+                const response = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                });
+                const body = await response.json();
+                expect(body).toEqual(responseBody);
+                await mock.getRequestsForAPI();
+            });
+
+            it('sets up a stub mapping in wiremock server with priority', async () => {
+                const requestBody = {
+                    objectKey: {
+                        intKey: 5,
+                        stringKey: 'stringKey',
+                    },
+                };
+                const responseBody = { test: 'testValue' };
+                const mockedStub = await mock.register(
+                    {
+                        body: requestBody,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                    { stubPriority: 1 },
+                );
+                expect(mockedStub.priority).toEqual(1);
+                const response = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                    body: JSON.stringify(requestBody),
+                });
+                const body = await response.json();
+                expect(body).toEqual(responseBody);
+                const calls = await mock.getRequestsForAPI();
+
+                const jestMock = jest.fn();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                calls.forEach((request: any) => {
+                    jestMock(request.request);
+                });
+                expect(jestMock).toHaveBeenCalledWith(
+                    expect.objectContaining({ body: JSON.stringify(requestBody) }),
+                );
+            });
+
+            it('sets up a stub mapping in wiremock server with higher priority', async () => {
+                const requestBody = {
+                    objectKey: {
+                        intKey: 5,
+                        stringKey: 'stringKey',
+                    },
+                };
+                const responseBodyLowPriority = { test: 'testValue' };
+                const responseBodyHighPriority = { test: 'biggerTestValue' };
+                await mock.register(
+                    {
+                        body: requestBody,
+                    },
+                    {
+                        status: 200,
+                        body: responseBodyHighPriority,
+                    },
+                    { stubPriority: 1 },
+                );
+                await mock.register(
+                    {
+                        body: requestBody,
+                    },
+                    {
+                        status: 200,
+                        body: responseBodyLowPriority,
+                    },
+                    { stubPriority: 2 },
+                );
+                const response = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                    body: JSON.stringify(requestBody),
+                });
+                const body = await response.json();
+                expect(body).toEqual(responseBodyHighPriority);
+                const calls = await mock.getRequestsForAPI();
+
+                const jestMock = jest.fn();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                calls.forEach((request: any) => {
+                    jestMock(request.request);
+                });
+                expect(jestMock).toHaveBeenCalledWith(
+                    expect.objectContaining({ body: JSON.stringify(requestBody) }),
+                );
+            });
+        });
+
+        describe('deleteMapping', () => {
+            it('sets up a stub mapping and deletes it', async () => {
+                const responseBody = { test: 'testValue' };
+
+                expect(await mock.getAllMappings()).toHaveLength(0);
+                const { id } = await mock.register(
+                    {},
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                );
+                expect(await mock.getAllMappings()).toHaveLength(1);
+                await mock.deleteMapping(id);
+                expect(await mock.getAllMappings()).toHaveLength(0);
+            });
+        });
+
+        describe('getMapping', () => {
+            it('sets up a stub mapping and returns it with get mappings', async () => {
+                const responseBody = { test: 'testValue' };
+
+                expect(await mock.getAllMappings()).toHaveLength(0);
+                await mock.register(
+                    {},
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                );
+                expect(await mock.getAllMappings()).toHaveLength(1);
+            });
+        });
+
+        describe('getRequests', () => {
+            it('returns number of unmatched requests', async () => {
+                await mock.register({}, { status: 200 });
+
+                for (let i = 0; i < 5; i++) {
+                    await fetch(wiremockUrl + testEndpoint, {
+                        method: 'GET',
+                    });
+                }
+                expect(await mock.getUnmatchedRequests()).toHaveLength(5);
+            });
+        });
+
+        describe('getScenarios', () => {
+            it('should return scenarios', async () => {
+                expect(await mock.getAllScenarios()).toHaveLength(0);
+                await mock.register({}, { status: 400 });
+                expect(await mock.getAllScenarios()).toHaveLength(0);
+                await mock.register(
+                    {},
+                    { status: 200 },
+                    {
+                        scenario: {
+                            scenarioName: 'test-scenario',
+                            requiredScenarioState: 'Started',
+                        },
+                    },
+                );
+                expect(await mock.getAllScenarios()).toHaveLength(1);
+            });
+        });
+
+        describe('resetScenarios', () => {
+            it('should return scenarios', async () => {
+                await mock.register(
+                    {},
+                    { status: 200 },
+                    {
+                        scenario: {
+                            scenarioName: 'test-scenario',
+                            requiredScenarioState: 'Started',
+                            newScenarioState: 'test-state',
+                        },
+                    },
+                );
+                await mock.register(
+                    {},
+                    { status: 201 },
+                    {
+                        scenario: {
+                            scenarioName: 'test-scenario',
+                            requiredScenarioState: 'test-state',
+                        },
+                    },
+                );
+
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+                let resp = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                });
+                expect(resp.status).toEqual(200);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                expect((await mock.getAllScenarios())[0].state).toEqual('test-state');
+                resp = await fetch(wiremockUrl + testEndpoint, {
+                    method: 'POST',
+                });
+                expect(resp.status).toEqual(201);
+                await mock.resetAllScenarios();
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+            });
+        });
+    });
+});

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -8,7 +8,7 @@ import { WireMockAPI } from '../../src';
 describe('Integration with WireMock', () => {
     // tslint:disable-next-line: no-http-string
     const wiremockUrl = 'http://localhost:8080';
-    const testEndpoint = '/testEndpoint';
+    const testEndpoint = '/test-endpoint';
     const testMethod = 'POST';
     const mock = new WireMockAPI(wiremockUrl, testEndpoint, testMethod);
 

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -16,7 +16,7 @@ describe('Integration with WireMock', () => {
         await mock.clearAll();
     });
 
-    describe('WireMock', () => {
+    describe('WireMockAPI', () => {
         describe('register', () => {
             it('sets up a stub mapping in wiremock server and expects mapping to be called', async () => {
                 const requestBody = {

--- a/test/unit/WireMock.spec.ts
+++ b/test/unit/WireMock.spec.ts
@@ -187,7 +187,7 @@ describe('WireMock', () => {
                     {
                         request: {
                             method: 'POST',
-                            url: '/testEndpoint',
+                            url: '/test-endpoint',
                             body: JSON.stringify(requestBody),
                             queryParams: {},
                             headers: {},
@@ -196,20 +196,20 @@ describe('WireMock', () => {
                     {
                         request: {
                             method: 'GET',
-                            url: '/testEndpoint',
+                            url: '/test-endpoint',
                             queryParams: {},
                             headers: {},
                         },
                     },
                 ],
             };
-            const calls = await mock.getRequestsForAPI('POST', '/testEndpoint');
+            const calls = await mock.getRequestsForAPI('POST', '/test-endpoint');
             expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/requests', {
                 method: 'GET',
             });
             expect(calls.length).toEqual(1);
 
-            const getCalls = await mock.getRequestsForAPI('GET', '/testEndpoint');
+            const getCalls = await mock.getRequestsForAPI('GET', '/test-endpoint');
             expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/requests', {
                 method: 'GET',
             });

--- a/test/unit/WireMockAPI.spec.ts
+++ b/test/unit/WireMockAPI.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
+// See the LICENSE file for license information.
+
+describe('WireMockAPI', () => {
+    const mockJson = { body: {} };
+    const mockNodeFetch = {
+        default: jest.fn().mockReturnValue({
+            json: jest.fn().mockImplementation(() => Promise.resolve(mockJson.body)),
+        }),
+    };
+
+    beforeEach(() => {
+        mockJson.body = {};
+        jest.mock('node-fetch', () => mockNodeFetch);
+    });
+
+    afterEach(() => {
+        jest.unmock('../../src/RequestModel');
+        jest.unmock('../../src/ResponseModel');
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
+    describe('register', () => {
+        it('should return empty response w/ priority and scenario', async () => {
+            jest.mock('../../src/RequestModel', () => ({
+                createWireMockRequest: jest.fn().mockName('mockedGetRequest'),
+            }));
+            jest.mock('../../src/ResponseModel', () => ({
+                createWireMockResponse: jest.fn().mockName('mockedGetResponse'),
+            }));
+            const wireMockApi = require('../../src/WireMockAPI');
+            const wireMockUrl = 'https://testservice/';
+            const wireMockEndpoint = '/test-endpoint';
+            const wireMockMethod = 'GET';
+            const mock = new wireMockApi.WireMockAPI(wireMockUrl, wireMockEndpoint, wireMockMethod);
+            const resp = await mock.register({}, {});
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+            expect(resp).toEqual({});
+        });
+    });
+
+    describe('registerDefaultResponse', () => {
+        it('should return empty response w/ priority and scenario', async () => {
+            jest.mock('../../src/RequestModel', () => ({
+                createWireMockRequest: jest.fn().mockName('mockedGetRequest'),
+            }));
+            jest.mock('../../src/ResponseModel', () => ({
+                createWireMockResponse: jest.fn().mockName('mockedGetResponse'),
+            }));
+            const wireMockApi = require('../../src/WireMockAPI');
+            const wireMockUrl = 'https://testservice/';
+            const wireMockEndpoint = '/test-endpoint';
+            const wireMockMethod = 'GET';
+            const mock = new wireMockApi.WireMockAPI(wireMockUrl, wireMockEndpoint, wireMockMethod);
+            const resp = await mock.registerDefaultResponse({
+                body: {},
+            });
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
+                method: 'POST',
+                body: JSON.stringify({}),
+            });
+            expect(resp).toEqual({});
+        });
+    });
+
+    describe('verify', () => {
+        it('verify calls', async () => {
+            const wireMockApi = require('../../src/WireMockAPI');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMockApi.WireMockAPI(wireMockUrl, '/testEndpoint', 'POST');
+
+            const requestBody = {
+                objectKey: {
+                    intKey: 5,
+                    stringKey: 'stringKey',
+                },
+            };
+
+            mockJson.body = {
+                requests: [
+                    {
+                        request: {
+                            method: 'POST',
+                            url: '/testEndpoint',
+                            body: JSON.stringify(requestBody),
+                            queryParams: {},
+                            headers: {},
+                        },
+                    },
+                ],
+            };
+            const calls = await mock.getRequestsForAPI();
+            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/requests', {
+                method: 'GET',
+            });
+            expect(calls.length).toEqual(1);
+        });
+    });
+});

--- a/test/unit/WireMockAPI.spec.ts
+++ b/test/unit/WireMockAPI.spec.ts
@@ -71,7 +71,9 @@ describe('WireMockAPI', () => {
         it('verify calls', async () => {
             const wireMockApi = require('../../src/WireMockAPI');
             const wireMockUrl = 'https://testservice/';
-            const mock = new wireMockApi.WireMockAPI(wireMockUrl, '/testEndpoint', 'POST');
+            const wireMockEndpoint = '/test-endpoint';
+            const wireMockMethod = 'POST';
+            const mock = new wireMockApi.WireMockAPI(wireMockUrl, wireMockEndpoint, wireMockMethod);
 
             const requestBody = {
                 objectKey: {
@@ -85,7 +87,7 @@ describe('WireMockAPI', () => {
                     {
                         request: {
                             method: 'POST',
-                            url: '/testEndpoint',
+                            url: '/test-endpoint',
                             body: JSON.stringify(requestBody),
                             queryParams: {},
                             headers: {},


### PR DESCRIPTION
### SUMMARY

Mostly only single APIs were mocked using WireMock but writing the mocks became verbose as `endpoint` and `method` had to be provided every time when a mock was getting created. This makes it easier to use WireMock when only a single API is in questions

### DETAILS

- add `WireMockAPI` that takes the `endpoint` and `method` as parameters

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
