### PR TITLE
replace node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,6 +1592,14 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
+        "axios": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+            "requires": {
+                "follow-redirects": "^1.14.4"
+            }
+        },
         "babel-jest": {
             "version": "27.3.1",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
@@ -1906,9 +1914,9 @@
             "dev": true
         },
         "ci-info": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-            "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+            "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
             "dev": true
         },
         "cint": {
@@ -1936,9 +1944,9 @@
             "dev": true
         },
         "cli-table": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.8.tgz",
-            "integrity": "sha512-5IO15fJRzgM+hHZjvQlqD6UPRuVGWR4Ny5ZzaM5VJxJEQqSIEVyVh9dMAUN6CBAVfMc4/6CFEzbhnRftLRCyug==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.9.tgz",
+            "integrity": "sha512-7eA6hFtAZwVx3dWAGoaBqTrzWko5jRUFKpHT64ZHkJpaA3y5wf5NlLjguqTRmqycatJZiwftODYYyGNLbQ7MuA==",
             "dev": true,
             "requires": {
                 "colors": "1.0.3",
@@ -2130,34 +2138,6 @@
                 "abab": "^2.0.3",
                 "whatwg-mimetype": "^2.3.0",
                 "whatwg-url": "^8.0.0"
-            },
-            "dependencies": {
-                "tr46": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-                    "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-                    "dev": true,
-                    "requires": {
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "webidl-conversions": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-                    "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-                    "dev": true
-                },
-                "whatwg-url": {
-                    "version": "8.7.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-                    "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.7.0",
-                        "tr46": "^2.1.0",
-                        "webidl-conversions": "^6.1.0"
-                    }
-                }
             }
         },
         "debug": {
@@ -2314,9 +2294,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.903",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.903.tgz",
-            "integrity": "sha512-+PnYAyniRRTkNq56cqYDLq9LyklZYk0hqoDy9GpcU11H5QjRmFZVDbxtgHUMK/YzdNTcn1XWP5gb+hFlSCr20g==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.0.tgz",
+            "integrity": "sha512-+oXCt6SaIu8EmFTPx8wNGSB0tHQ5biDscnlf6Uxuz17e9CjzMRtGk9B8705aMPnj0iWr3iC74WuIkngCsLElmA==",
             "dev": true
         },
         "emittery": {
@@ -2995,6 +2975,11 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
             "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
             "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -4462,32 +4447,6 @@
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
                     "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
                     "dev": true
-                },
-                "tr46": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-                    "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-                    "dev": true,
-                    "requires": {
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "webidl-conversions": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-                    "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-                    "dev": true
-                },
-                "whatwg-url": {
-                    "version": "8.7.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-                    "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.7.0",
-                        "tr46": "^2.1.0",
-                        "webidl-conversions": "^6.1.0"
-                    }
                 }
             }
         },
@@ -4990,14 +4949,6 @@
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
             "dev": true
-        },
-        "node-fetch": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-            "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            }
         },
         "node-gyp": {
             "version": "7.1.2",
@@ -6339,9 +6290,9 @@
             }
         },
         "socks-proxy-agent": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-            "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+            "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
             "dev": true,
             "requires": {
                 "agent-base": "^6.0.2",
@@ -6356,9 +6307,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.20",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-            "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -6594,9 +6545,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.8.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.1.tgz",
-                    "integrity": "sha512-6CiMNDrzv0ZR916u2T+iRunnD60uWmNn8SkdB44/6stVORUg0aAkWO7PkOhpCmjmW8f2I/G/xnowD66fxGyQJg==",
+                    "version": "8.8.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+                    "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -6699,9 +6650,13 @@
             }
         },
         "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+            "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.1"
+            }
         },
         "ts-jest": {
             "version": "27.0.5",
@@ -6731,9 +6686,9 @@
             }
         },
         "tsconfig-paths": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-            "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+            "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
             "dev": true,
             "requires": {
                 "@types/json5": "^0.0.29",
@@ -7010,9 +6965,10 @@
             }
         },
         "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+            "dev": true
         },
         "whatwg-encoding": {
             "version": "1.0.5",
@@ -7030,12 +6986,14 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+            "dev": true,
             "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "lodash": "^4.7.0",
+                "tr46": "^2.1.0",
+                "webidl-conversions": "^6.1.0"
             }
         },
         "which": {
@@ -7114,9 +7072,9 @@
             }
         },
         "ws": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+            "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
             "dev": true
         },
         "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "npm": ">=6.14.5"
     },
     "dependencies": {
-        "node-fetch": "2.6.5"
+        "axios": "0.24.0"
     },
     "devDependencies": {
         "@rushstack/eslint-config": "2.4.1",

--- a/src/IWireMockTypes.ts
+++ b/src/IWireMockTypes.ts
@@ -30,9 +30,13 @@ export interface IResponseMock {
 
 export interface IWireMockMockedRequestResponse {
     id: string;
-    request: IRequestMock;
-    response: IResponseMock;
+    newScenarioState?: string;
     priority?: number;
+    request: IRequestMock;
+    requiredScenarioState?: string;
+    response: IResponseMock;
+    scenarioName?: string;
+    uuid: number;
 }
 
 export interface IWireMockScenario {

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -2,7 +2,7 @@
 // See the LICENSE file for license information.
 
 import { describe, expect, it } from '@jest/globals';
-import fetch from 'node-fetch';
+import axios from 'axios';
 
 import { WireMock } from '../../src';
 
@@ -38,11 +38,8 @@ describe('Integration with WireMock', () => {
                     },
                 );
 
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 const calls = await mock.getRequestsForAPI('POST', testEndpoint);
 
@@ -70,10 +67,8 @@ describe('Integration with WireMock', () => {
                     },
                 );
 
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 await mock.getRequestsForAPI('POST', testEndpoint);
             });
@@ -100,11 +95,8 @@ describe('Integration with WireMock', () => {
                     { stubPriority: 1 },
                 );
                 expect(mockedStub.priority).toEqual(1);
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 const calls = await mock.getRequestsForAPI('POST', testEndpoint);
 
@@ -152,11 +144,8 @@ describe('Integration with WireMock', () => {
                     },
                     { stubPriority: 2 },
                 );
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBodyHighPriority);
                 const calls = await mock.getRequestsForAPI('POST', testEndpoint);
 
@@ -219,9 +208,7 @@ describe('Integration with WireMock', () => {
                 await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
-                    await fetch(wiremockUrl + testEndpoint, {
-                        method: 'GET',
-                    });
+                    await axios.get(wiremockUrl + testEndpoint);
                 }
                 expect(await mock.getAllRequests()).toHaveLength(5);
             });
@@ -231,9 +218,9 @@ describe('Integration with WireMock', () => {
                 await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
-                    await fetch(wiremockUrl + testEndpoint, {
-                        method: 'POST',
-                    });
+                    try {
+                        await axios.post(wiremockUrl + testEndpoint);
+                    } catch (error) {}
                 }
                 expect(await mock.getUnmatchedRequests()).toHaveLength(5);
             });
@@ -287,16 +274,12 @@ describe('Integration with WireMock', () => {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 expect((await mock.getAllScenarios())[0].state).toEqual('Started');
-                let resp = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'GET',
-                });
+                let resp = await axios.get(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(200);
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 expect((await mock.getAllScenarios())[0].state).toEqual('test-state');
-                resp = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'GET',
-                });
+                resp = await axios.get(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(201);
                 await mock.resetAllScenarios();
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -2,7 +2,7 @@
 // See the LICENSE file for license information.
 
 import { describe, expect, it } from '@jest/globals';
-import fetch from 'node-fetch';
+import axios from 'axios';
 
 import { WireMockAPI } from '../../src';
 
@@ -37,11 +37,8 @@ describe('Integration with WireMock', () => {
                     },
                 );
 
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 const calls = await mock.getRequestsForAPI();
 
@@ -65,10 +62,8 @@ describe('Integration with WireMock', () => {
                     },
                 );
 
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 await mock.getRequestsForAPI();
             });
@@ -92,11 +87,8 @@ describe('Integration with WireMock', () => {
                     { stubPriority: 1 },
                 );
                 expect(mockedStub.priority).toEqual(1);
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBody);
                 const calls = await mock.getRequestsForAPI();
 
@@ -139,11 +131,8 @@ describe('Integration with WireMock', () => {
                     },
                     { stubPriority: 2 },
                 );
-                const response = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                    body: JSON.stringify(requestBody),
-                });
-                const body = await response.json();
+                const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
+                const body = response.data;
                 expect(body).toEqual(responseBodyHighPriority);
                 const calls = await mock.getRequestsForAPI();
 
@@ -197,9 +186,9 @@ describe('Integration with WireMock', () => {
                 await mock.register({}, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
-                    await fetch(wiremockUrl + testEndpoint, {
-                        method: 'GET',
-                    });
+                    try {
+                        await axios.get(wiremockUrl + testEndpoint);
+                    } catch (error) {}
                 }
                 expect(await mock.getUnmatchedRequests()).toHaveLength(5);
             });
@@ -251,16 +240,12 @@ describe('Integration with WireMock', () => {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 expect((await mock.getAllScenarios())[0].state).toEqual('Started');
-                let resp = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                });
+                let resp = await axios.post(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(200);
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 expect((await mock.getAllScenarios())[0].state).toEqual('test-state');
-                resp = await fetch(wiremockUrl + testEndpoint, {
-                    method: 'POST',
-                });
+                resp = await axios.post(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(201);
                 await mock.resetAllScenarios();
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/unit/WireMockAPI.spec.ts
+++ b/test/unit/WireMockAPI.spec.ts
@@ -2,17 +2,21 @@
 // See the LICENSE file for license information.
 
 describe('WireMockAPI', () => {
-    const mockJson = { body: {} };
-    const mockNodeFetch = {
-        default: jest.fn().mockReturnValue({
-            json: jest.fn().mockImplementation(() => Promise.resolve(mockJson.body)),
-        }),
-        Headers: jest.fn().mockReturnValue({}),
+    const mockData = {
+        data: {},
+    };
+    const mockAxios = {
+        default: {
+            delete: jest.fn().mockResolvedValue(mockData as never),
+            get: jest.fn().mockResolvedValue(mockData as never),
+            post: jest.fn().mockResolvedValue(mockData as never),
+        },
+        AxiosRequestHeaders: jest.fn(),
+        AxiosResponse: jest.fn(),
     };
 
     beforeEach(() => {
-        mockJson.body = {};
-        jest.mock('node-fetch', () => mockNodeFetch);
+        jest.mock('axios', () => mockAxios);
     });
 
     afterEach(() => {
@@ -36,11 +40,11 @@ describe('WireMockAPI', () => {
             const wireMockMethod = 'GET';
             const mock = new wireMockApi.WireMockAPI(wireMockUrl, wireMockEndpoint, wireMockMethod);
             const resp = await mock.register({}, {});
-            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
-                method: 'POST',
-                body: JSON.stringify({}),
-                headers: {},
-            });
+            expect(mockAxios.default.post).toHaveBeenCalledWith(
+                wireMockUrl + '__admin/mappings',
+                {},
+                { headers: { 'Content-Type': 'application/json' } },
+            );
             expect(resp).toEqual({});
         });
     });
@@ -61,11 +65,11 @@ describe('WireMockAPI', () => {
             const resp = await mock.registerDefaultResponse({
                 body: {},
             });
-            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings', {
-                method: 'POST',
-                body: JSON.stringify({}),
-                headers: {},
-            });
+            expect(mockAxios.default.post).toHaveBeenCalledWith(
+                wireMockUrl + '__admin/mappings',
+                {},
+                { headers: { 'Content-Type': 'application/json' } },
+            );
             expect(resp).toEqual({});
         });
     });
@@ -85,7 +89,7 @@ describe('WireMockAPI', () => {
                 },
             };
 
-            mockJson.body = {
+            mockData.data = {
                 requests: [
                     {
                         request: {
@@ -99,9 +103,7 @@ describe('WireMockAPI', () => {
                 ],
             };
             const calls = await mock.getRequestsForAPI();
-            expect(mockNodeFetch.default).toHaveBeenCalledWith(wireMockUrl + '__admin/requests', {
-                method: 'GET',
-            });
+            expect(mockAxios.default.get).toHaveBeenCalledWith(wireMockUrl + '__admin/requests');
             expect(calls.length).toEqual(1);
         });
     });


### PR DESCRIPTION
### SUMMARY

Remove `node-fetch` as primary request library

### DETAILS

- Replace `node-fetch` with `axios`
- Update tests and relevant types

### CHECKLIST
- [ ] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
