### PR TITLE
Change to wiremock/wiremock docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ OK = @echo ${TIME}${GREEN}$1${CNone}${SPACE}
 INFO = echo ${TIME}${BLUE}$1${CNone}${SPACE}
 
 start-wiremock:
-	@docker run -itd --rm --name wiremock-container -p 8080:8080 rodolpheche/wiremock:2.27.2 --record-mappings --verbose
+	@docker run -itd --rm --name wiremock-container -p 8080:8080 wiremock/wiremock:2.31.0 --record-mappings --verbose
 	$(call OK, start-wiremock complete...)
 
 start-dependencies:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Here's how to set up WireMock Captain.  The demo project can be copy+pasted as a
    $ cd wiremock-captain/examples/express-app
 
    # Start the WireMock simulator
-   $ docker run -itd --rm -p 8080:8080 --name mocked-service rodolpheche/wiremock:2.27.2
+   $ docker run -itd --rm -p 8080:8080 --name mocked-service wiremock/wiremock:2.31.0
 
    # Start the service in development mode
    $ npm run dev
@@ -102,7 +102,7 @@ failed.
 Assuming the wiremock docker instance is already running using the following command:
 
 ```bash
-docker run -itd --rm --name wiremock-container -p 8080:8080 rodolpheche/wiremock:2.27.2 --record-mappings --verbose
+docker run -itd --rm --name wiremock-container -p 8080:8080 wiremock/wiremock:2.31.0 --record-mappings --verbose
 ```
 
 Typical usage looks like this:

--- a/examples/express-app/README.md
+++ b/examples/express-app/README.md
@@ -18,6 +18,6 @@ npm run dev
 Running the tests:
 
 ```bash
-docker run -itd --rm -p 8080:8080 --name mocked-service rodolpheche/wiremock:2.27.2 --verbose
+docker run -itd --rm -p 8080:8080 --name mocked-service wiremock/wiremock:2.31.0 --verbose
 npm run test
 ```


### PR DESCRIPTION
### SUMMARY

The rodolpheche/wiremock docker image has been deprecated in favor of the wiremock/wiremock image provided and maintained by the Wiremock Organization.
