### PR TITLE
support reset mappings

### DIFF
--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -73,6 +73,13 @@ export class WireMock {
     }
 
     /**
+     * Removes all the existing mappings not defined in backing store and logs of incoming requests
+     */
+    public clearAllExceptDefault(): Promise<AxiosResponse[]> {
+        return Promise.all([this.resetMappings(), this.clearAllRequests()]);
+    }
+
+    /**
      * Removes all existing stubs
      */
     public async clearAllMappings(): Promise<AxiosResponse> {

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -73,7 +73,8 @@ export class WireMock {
     }
 
     /**
-     * Removes all the existing mappings not defined in backing store and logs of incoming requests
+     * Removes all the non-default mappings (not defined in backing store)
+     * and logs of incoming requests
      */
     public clearAllExceptDefault(): Promise<AxiosResponse[]> {
         return Promise.all([this.resetMappings(), this.clearAllRequests()]);

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -165,6 +165,13 @@ export class WireMock {
         return await axios.post(this.makeUrl(WIREMOCK_SCENARIO_URL + '/reset'));
     }
 
+    /**
+     * Restores stub mappings to the defaults defined back in the backing store
+     */
+    public async resetMappings(): Promise<AxiosResponse> {
+        return await axios.post(this.makeUrl(WIREMOCK_MAPPINGS_URL + '/reset'));
+    }
+
     protected makeUrl(endpoint: string): string {
         return new URL(endpoint, this.baseUrl).href;
     }

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -252,7 +252,7 @@ describe('Integration with WireMock', () => {
                 const responseBody = { test: 'testValue' };
 
                 expect(await mock.getAllMappings()).toHaveLength(0);
-                const { id } = await mock.register(
+                await mock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -246,6 +246,28 @@ describe('Integration with WireMock', () => {
             });
         });
 
+        describe('resetMappings', () => {
+            it('sets up a stub mapping and deletes it', async () => {
+                const testEndpoint = '/test-endpoint';
+                const responseBody = { test: 'testValue' };
+
+                expect(await mock.getAllMappings()).toHaveLength(0);
+                const { id } = await mock.register(
+                    {
+                        method: 'POST',
+                        endpoint: testEndpoint,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                );
+                expect(await mock.getAllMappings()).toHaveLength(1);
+                await mock.resetMappings();
+                expect(await mock.getAllMappings()).toHaveLength(0);
+            });
+        });
+
         describe('resetScenarios', () => {
             it('should return scenarios', async () => {
                 const testEndpoint = '/test-endpoint';

--- a/test/unit/WireMock.spec.ts
+++ b/test/unit/WireMock.spec.ts
@@ -164,6 +164,18 @@ describe('WireMock', () => {
         });
     });
 
+    describe('resetMapping', () => {
+        it('should reset mappings', async () => {
+            const wireMock = require('../../src/WireMock');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMock.WireMock(wireMockUrl);
+            await mock.resetMappings();
+            expect(mockAxios.default.post).toHaveBeenCalledWith(
+                wireMockUrl + '__admin/mappings/reset',
+            );
+        });
+    });
+
     describe('verify', () => {
         it('verify calls', async () => {
             const wireMock = require('../../src/WireMock');

--- a/test/unit/WireMock.spec.ts
+++ b/test/unit/WireMock.spec.ts
@@ -37,6 +37,17 @@ describe('WireMock', () => {
             expect(mockAxios.default.delete).toHaveBeenCalledWith(wireMockUrl + '__admin/mappings');
             expect(mockAxios.default.delete).toHaveBeenCalledWith(wireMockUrl + '__admin/requests');
         });
+
+        it('clears all except default', async () => {
+            const wireMock = require('../../src/WireMock');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMock.WireMock(wireMockUrl);
+            await mock.clearAllExceptDefault();
+            expect(mockAxios.default.post).toHaveBeenCalledWith(
+                wireMockUrl + '__admin/mappings/reset',
+            );
+            expect(mockAxios.default.delete).toHaveBeenCalledWith(wireMockUrl + '__admin/requests');
+        });
     });
 
     describe('deleteMapping', () => {


### PR DESCRIPTION
### SUMMARY

Add support for new mapping reset function

Fixes #58 

### DETAILS

- support new reset mapping function
- add a clear function to clear non-default mappings

### CHECKLIST
- [ ] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
