### PR TITLE
add default response header

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     clearMocks: true,
     collectCoverageFrom: ['src/**/*.ts'],
+    coveragePathIgnorePatterns: ['index.ts'],
     coverageReporters: ['cobertura', 'html', 'text-summary', 'text'],
     coverageThreshold: {
         global: {

--- a/src/IWireMockFeatures.ts
+++ b/src/IWireMockFeatures.ts
@@ -26,13 +26,13 @@ export interface IWireMockFeatures {
     stubPriority?: number;
 }
 
-export enum BodyType {
+export const enum BodyType {
     Default = 'jsonBody',
     Body = 'body',
     Base64Body = 'base64Body',
 }
 
-export enum MatchingAttributes {
+export const enum MatchingAttributes {
     BinaryEqualTo = 'binaryEqualTo',
     Contains = 'contains',
     DoesNotMatch = 'doesNotMatch',
@@ -42,7 +42,7 @@ export enum MatchingAttributes {
     MatchesJsonPath = 'matchesJsonPath',
 }
 
-export enum EndpointFeature {
+export const enum EndpointFeature {
     Default = 'url',
     UrlPath = 'urlPath',
     UrlPathPattern = 'urlPathPattern',

--- a/src/RequestModel.ts
+++ b/src/RequestModel.ts
@@ -10,7 +10,7 @@ export function createWireMockRequest(
     features?: IWireMockFeatures,
 ): IRequestMock {
     const { body, cookies, headers, method, queryParameters, endpoint } = request;
-    const endpointFeature: string = features?.requestEndpointFeature || EndpointFeature.Default;
+    const endpointFeature: string = features?.requestEndpointFeature ?? EndpointFeature.Default;
 
     const mock: IRequestMock = {
         method,
@@ -18,7 +18,7 @@ export function createWireMockRequest(
     mock[endpointFeature] = endpoint;
 
     if (body) {
-        const bodyFeature: string = features?.requestBodyFeature || MatchingAttributes.EqualToJson;
+        const bodyFeature: string = features?.requestBodyFeature ?? MatchingAttributes.EqualToJson;
         const mockBody: { [key: string]: unknown } = {};
         mockBody[bodyFeature] = body;
         mock.bodyPatterns = [mockBody];
@@ -56,7 +56,7 @@ function getMockedObject(
     for (const key of Object.keys(dict)) {
         mockObject[key] = mapPropertyToAttribute(
             dict[key],
-            dictMatchingAttributes?.[key] || MatchingAttributes.EqualTo,
+            dictMatchingAttributes?.[key] ?? MatchingAttributes.EqualTo,
         );
     }
     return mockObject;

--- a/src/ResponseModel.ts
+++ b/src/ResponseModel.ts
@@ -13,14 +13,19 @@ export function createWireMockResponse(
     const mockedResponse: IResponseMock = {
         status,
     };
+    const bodyType: string = features?.responseBodyType ?? BodyType.Default;
 
     if (body) {
-        const bodyType: string = features?.responseBodyType || BodyType.Default;
         mockedResponse[bodyType] = body;
     }
 
     if (headers) {
-        mockedResponse.headers = headers;
+        mockedResponse.headers = {
+            ...(bodyType === BodyType.Default && {
+                'Content-Type': 'application/json; charset=utf-8',
+            }),
+            ...headers,
+        };
     }
 
     return mockedResponse;

--- a/test/unit/ResponseModel.spec.ts
+++ b/test/unit/ResponseModel.spec.ts
@@ -55,7 +55,7 @@ describe('ResponseModel', () => {
             });
             expect(mockedResponse).toEqual({
                 status: 200,
-                headers: { Accept: 'json' },
+                headers: { Accept: 'json', 'Content-Type': 'application/json; charset=utf-8' },
             });
         });
     });


### PR DESCRIPTION
### SUMMARY

Add response header in case body is JSON by default

### DETAILS

- default header that can be overridden
- use nullish coalescing
- use `const` enums
- ignore `index.ts` coverage

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
