### PR TITLE
support response delay

### DIFF
--- a/src/IWireMockFeatures.ts
+++ b/src/IWireMockFeatures.ts
@@ -16,6 +16,7 @@ export interface IWireMockFeatures {
     requestHeaderFeatures?: Record<string, MatchingAttributes>;
     requestQueryParamFeatures?: Record<string, MatchingAttributes>;
     responseBodyType?: BodyType;
+    responseDelay?: Delay;
     /**
      * All the scenarios start from state `Started`
      */
@@ -48,3 +49,35 @@ export const enum EndpointFeature {
     UrlPathPattern = 'urlPathPattern',
     UrlPattern = 'urlPattern',
 }
+
+export const enum DelayType {
+    CHUNKED_DRIBBLE = 'CHUNKED_DRIBBLE',
+    FIXED = 'FIXED',
+    LOG_NORMAL = 'LOG_NORMAL',
+    UNIFORM = 'UNIFORM',
+}
+
+export interface IFixedDelay {
+    type: DelayType.FIXED;
+    constantDelay: number;
+}
+
+export interface ILogNormalDelay {
+    type: DelayType.LOG_NORMAL;
+    median: number;
+    sigma: number;
+}
+
+export interface IUniformDelay {
+    type: DelayType.UNIFORM;
+    lower: number;
+    upper: number;
+}
+
+export interface IChunkedDribbleDelay {
+    type: DelayType.CHUNKED_DRIBBLE;
+    numberOfChunks: number;
+    totalDuration: number;
+}
+
+export type Delay = IChunkedDribbleDelay | IFixedDelay | ILogNormalDelay | IUniformDelay;

--- a/src/IWireMockTypes.ts
+++ b/src/IWireMockTypes.ts
@@ -24,6 +24,9 @@ export interface IRequestMock {
 export interface IResponseMock {
     status: number;
     headers?: Record<string, KeyValue>;
+    fixedDelayMilliseconds?: number;
+    delayDistribution?: Record<string, number | string>;
+    chunkedDribbleDelay?: Record<string, number>;
 
     [key: string]: unknown;
 }

--- a/src/ResponseModel.ts
+++ b/src/ResponseModel.ts
@@ -28,25 +28,31 @@ export function createWireMockResponse(
 
     const delay = features?.responseDelay;
 
-    if (delay?.type === DelayType.CHUNKED_DRIBBLE) {
-        mockedResponse.chunkedDribbleDelay = {
-            numberOfChunks: delay.numberOfChunks,
-            totalDuration: delay.totalDuration,
-        };
-    } else if (delay?.type === DelayType.FIXED) {
-        mockedResponse.fixedDelayMilliseconds = delay.constantDelay;
-    } else if (delay?.type === DelayType.LOG_NORMAL) {
-        mockedResponse.delayDistribution = {
-            type: 'lognormal',
-            median: delay.median,
-            sigma: delay.sigma,
-        };
-    } else if (delay?.type === DelayType.UNIFORM) {
-        mockedResponse.delayDistribution = {
-            type: 'uniform',
-            lower: delay.lower,
-            upper: delay.upper,
-        };
+    switch (delay?.type) {
+        case DelayType.CHUNKED_DRIBBLE:
+            mockedResponse.chunkedDribbleDelay = {
+                numberOfChunks: delay.numberOfChunks,
+                totalDuration: delay.totalDuration,
+            };
+            break;
+        case DelayType.FIXED:
+            mockedResponse.fixedDelayMilliseconds = delay.constantDelay;
+            break;
+        case DelayType.LOG_NORMAL:
+            mockedResponse.delayDistribution = {
+                type: 'lognormal',
+                median: delay.median,
+                sigma: delay.sigma,
+            };
+            break;
+        case DelayType.UNIFORM:
+            mockedResponse.delayDistribution = {
+                type: 'uniform',
+                lower: delay.lower,
+                upper: delay.upper,
+            };
+            break;
+        default:
     }
 
     return mockedResponse;

--- a/src/ResponseModel.ts
+++ b/src/ResponseModel.ts
@@ -1,7 +1,7 @@
 // Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
 // See the LICENSE file for license information.
 
-import { BodyType, IWireMockFeatures } from './IWireMockFeatures';
+import { BodyType, DelayType, IWireMockFeatures } from './IWireMockFeatures';
 import { IWireMockResponse } from './IWireMockResponse';
 import { IResponseMock } from './IWireMockTypes';
 
@@ -19,12 +19,33 @@ export function createWireMockResponse(
         mockedResponse[bodyType] = body;
     }
 
-    if (headers) {
-        mockedResponse.headers = {
-            ...(bodyType === BodyType.Default && {
-                'Content-Type': 'application/json; charset=utf-8',
-            }),
-            ...headers,
+    mockedResponse.headers = {
+        ...(bodyType === BodyType.Default && {
+            'Content-Type': 'application/json; charset=utf-8',
+        }),
+        ...headers,
+    };
+
+    const delay = features?.responseDelay;
+
+    if (delay?.type === DelayType.CHUNKED_DRIBBLE) {
+        mockedResponse.chunkedDribbleDelay = {
+            numberOfChunks: delay.numberOfChunks,
+            totalDuration: delay.totalDuration,
+        };
+    } else if (delay?.type === DelayType.FIXED) {
+        mockedResponse.fixedDelayMilliseconds = delay.constantDelay;
+    } else if (delay?.type === DelayType.LOG_NORMAL) {
+        mockedResponse.delayDistribution = {
+            type: 'lognormal',
+            median: delay.median,
+            sigma: delay.sigma,
+        };
+    } else if (delay?.type === DelayType.UNIFORM) {
+        mockedResponse.delayDistribution = {
+            type: 'uniform',
+            lower: delay.lower,
+            upper: delay.upper,
         };
     }
 

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -54,6 +54,7 @@ describe('Integration with WireMock', () => {
                     expect.objectContaining({ body: JSON.stringify(requestBody) }),
                 );
             });
+
             it('sets up a stub mapping in wiremock server and expects mapping to be called w/ delay', async () => {
                 const requestBody = {
                     objectKey: {

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -42,7 +42,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                expect(Date.now() - start).toBeLessThan(1000);
+                expect(Date.now() - start).toBeLessThan(300);
                 const calls = await mock.getRequestsForAPI('POST', testEndpoint);
 
                 const jestMock = jest.fn();
@@ -77,7 +77,7 @@ describe('Integration with WireMock', () => {
                     {
                         responseDelay: {
                             type: DelayType.FIXED,
-                            constantDelay: 1000,
+                            constantDelay: 300,
                         },
                     },
                 );
@@ -86,7 +86,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                expect(Date.now() - start).toBeGreaterThanOrEqual(1000);
+                expect(Date.now() - start).toBeGreaterThanOrEqual(300);
             });
 
             it('sets up a stub mapping in wiremock server without body', async () => {

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -14,7 +14,7 @@ describe('Integration with WireMock', () => {
     const mock = new WireMockAPI(wiremockUrl, testEndpoint, testMethod);
 
     beforeEach(async () => {
-        await mock.clearAll();
+        await mock.clearAllExceptDefault();
     });
 
     describe('WireMockAPI', () => {

--- a/test/unit/ResponseModel.spec.ts
+++ b/test/unit/ResponseModel.spec.ts
@@ -3,7 +3,7 @@
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import { BodyType } from '../../src';
+import { BodyType, DelayType } from '../../src';
 
 describe('ResponseModel', () => {
     beforeEach(() => {
@@ -17,7 +17,10 @@ describe('ResponseModel', () => {
             const mockedResponse = testModule.createWireMockResponse({
                 status: 200,
             });
-            expect(mockedResponse).toEqual({ status: 200 });
+            expect(mockedResponse).toEqual({
+                status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            });
         });
 
         it('builds with statusCode and body', () => {
@@ -28,6 +31,7 @@ describe('ResponseModel', () => {
             });
             expect(mockedResponse).toEqual({
                 status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
                 jsonBody: { testKey: 'test-value' },
             });
         });
@@ -43,6 +47,7 @@ describe('ResponseModel', () => {
             );
             expect(mockedResponse).toEqual({
                 status: 200,
+                headers: {},
                 body: { testKey: 'test-value' },
             });
         });
@@ -56,6 +61,95 @@ describe('ResponseModel', () => {
             expect(mockedResponse).toEqual({
                 status: 200,
                 headers: { Accept: 'json', 'Content-Type': 'application/json; charset=utf-8' },
+            });
+        });
+
+        it('should build response with chunked dribble delay', () => {
+            const testModule: typeof import('../../src/ResponseModel') = require('../../src/ResponseModel');
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                },
+                {
+                    responseDelay: {
+                        type: DelayType.CHUNKED_DRIBBLE,
+                        numberOfChunks: 1,
+                        totalDuration: 100,
+                    },
+                },
+            );
+            expect(mockedResponse).toEqual({
+                status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                chunkedDribbleDelay: {
+                    numberOfChunks: 1,
+                    totalDuration: 100,
+                },
+            });
+        });
+
+        it('should build response with fixed delay', () => {
+            const testModule: typeof import('../../src/ResponseModel') = require('../../src/ResponseModel');
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                },
+                { responseDelay: { type: DelayType.FIXED, constantDelay: 100 } },
+            );
+            expect(mockedResponse).toEqual({
+                status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                fixedDelayMilliseconds: 100,
+            });
+        });
+
+        it('should build response with log normal delay', () => {
+            const testModule: typeof import('../../src/ResponseModel') = require('../../src/ResponseModel');
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                },
+                {
+                    responseDelay: {
+                        type: DelayType.LOG_NORMAL,
+                        median: 5,
+                        sigma: 10,
+                    },
+                },
+            );
+            expect(mockedResponse).toEqual({
+                status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                delayDistribution: {
+                    type: 'lognormal',
+                    median: 5,
+                    sigma: 10,
+                },
+            });
+        });
+
+        it('should build response with log normal delay', () => {
+            const testModule: typeof import('../../src/ResponseModel') = require('../../src/ResponseModel');
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                },
+                {
+                    responseDelay: {
+                        type: DelayType.UNIFORM,
+                        lower: 5,
+                        upper: 10,
+                    },
+                },
+            );
+            expect(mockedResponse).toEqual({
+                status: 200,
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+                delayDistribution: {
+                    type: 'uniform',
+                    lower: 5,
+                    upper: 10,
+                },
             });
         });
     });


### PR DESCRIPTION
### SUMMARY

Add response delay support

### DETAILS

- support response delay w/ 4 type as supported by wiremock. more info: https://wiremock.org/docs/simulating-faults/

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
