### PR TITLE
fix: export Method type

### DIFF
--- a/src/externalTypes.ts
+++ b/src/externalTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
 // See the LICENSE file for license information.
 
-import { KeyValue, Method, WebhookBody } from './internalTypes';
+import { KeyValue, WebhookBody } from './internalTypes';
 
 export interface IWireMockScenario {
     scenarioName: string;
@@ -69,5 +69,17 @@ export const enum MatchingAttributes {
     Matches = 'matches',
     MatchesJsonPath = 'matchesJsonPath',
 }
+
+export type Method =
+    | 'ANY'
+    | 'CONNECT'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PUT'
+    | 'TRACE';
 
 export type WireMockDelay = IChunkedDribbleDelay | IFixedDelay | ILogNormalDelay | IUniformDelay;

--- a/src/externalTypes.ts
+++ b/src/externalTypes.ts
@@ -1,7 +1,7 @@
 // Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
 // See the LICENSE file for license information.
 
-import { KeyValue, WebhookBody } from './internalTypes';
+import { KeyValue, Method, WebhookBody } from './internalTypes';
 
 export interface IWireMockScenario {
     scenarioName: string;
@@ -70,16 +70,6 @@ export const enum MatchingAttributes {
     MatchesJsonPath = 'matchesJsonPath',
 }
 
-export type Method =
-    | 'ANY'
-    | 'CONNECT'
-    | 'DELETE'
-    | 'GET'
-    | 'HEAD'
-    | 'OPTIONS'
-    | 'PATCH'
-    | 'POST'
-    | 'PUT'
-    | 'TRACE';
+export { Method };
 
 export type WireMockDelay = IChunkedDribbleDelay | IFixedDelay | ILogNormalDelay | IUniformDelay;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -63,6 +63,18 @@ export interface IWebhook {
 
 export type KeyValue = boolean | number | string;
 
+export type Method =
+    | 'ANY'
+    | 'CONNECT'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PUT'
+    | 'TRACE';
+
 export type WebhookBody =
     | { type: 'JSON'; data: Record<string, unknown> }
     | { type: 'String'; data: string };

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -63,18 +63,6 @@ export interface IWebhook {
 
 export type KeyValue = boolean | number | string;
 
-export type Method =
-    | 'ANY'
-    | 'CONNECT'
-    | 'DELETE'
-    | 'GET'
-    | 'HEAD'
-    | 'OPTIONS'
-    | 'PATCH'
-    | 'POST'
-    | 'PUT'
-    | 'TRACE';
-
 export type WebhookBody =
     | { type: 'JSON'; data: Record<string, unknown> }
     | { type: 'String'; data: string };


### PR DESCRIPTION
### SUMMARY

Recent release made `Method` an internal type. Fix that

### DETAILS

n/a

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
