### PR TITLE
feat: suport response fault

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -223,6 +223,30 @@ it to work, an additional webhook `.jar` extension is required to be available
 to the WireMock docker instance. Visit [here](https://wiremock.org/docs/docker/)
 or `<root>/scripts/setup.sh` for examples
 
+### Response fault
+
+The following mock will return an empty response (no status code, no body)
+when matched. This can be used to test for socket timeouts, connection resets,
+etc.
+
+```typescript
+await mock.register(
+    {
+        method: 'GET',
+        endpoint: '/test-endpoint',
+    },
+    {
+        status: 200,
+        body: {
+            hello: 'world',
+        },
+    },
+    {
+        fault: WireMockFault.EMPTY_RESPONSE,
+    },
+);
+```
+
 ### Usage with jest
 Jest `expect` works well with `WireMock-Captain` and can used for various kinds of checks
 ```typescript

--- a/src/IWireMockFeatures.ts
+++ b/src/IWireMockFeatures.ts
@@ -8,6 +8,7 @@ import {
     IWireMockWebhook,
     MatchingAttributes,
     WireMockDelay,
+    WireMockFault,
 } from './externalTypes';
 
 /**
@@ -17,6 +18,10 @@ import {
  * For more info how each of these work, visit: http://wiremock.org/docs/
  */
 export interface IWireMockFeatures {
+    /**
+     * If provided, will override any response status and body
+     */
+    fault?: WireMockFault;
     requestBodyFeature?: MatchingAttributes;
     requestCookieFeatures?: Record<string, MatchingAttributes>;
     requestEndpointFeature?: EndpointFeature;

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -80,6 +80,10 @@ export class WireMock {
             ];
         }
 
+        if (features?.fault) {
+            mock.response = { fault: features.fault };
+        }
+
         const wiremockResponse = await axios.post(this.makeUrl(WIREMOCK_MAPPINGS_URL), mock, {
             headers: HEADERS,
         });

--- a/src/externalTypes.ts
+++ b/src/externalTypes.ts
@@ -70,6 +70,13 @@ export const enum MatchingAttributes {
     MatchesJsonPath = 'matchesJsonPath',
 }
 
+export const enum WireMockFault {
+    CONNECTION_RESET_BY_PEER = 'CONNECTION_RESET_BY_PEER',
+    EMPTY_RESPONSE = 'EMPTY_RESPONSE',
+    MALFORMED_RESPONSE_CHUNK = 'MALFORMED_RESPONSE_CHUNK',
+    RANDOM_DATA_THEN_CLOSE = 'RANDOM_DATA_THEN_CLOSE',
+}
+
 export { Method };
 
 export type WireMockDelay = IChunkedDribbleDelay | IFixedDelay | ILogNormalDelay | IUniformDelay;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,6 +1,8 @@
 // Copyright (c) WarnerMedia Direct, LLC. All rights reserved. Licensed under the MIT license.
 // See the LICENSE file for license information.
 
+import { WireMockFault } from './externalTypes';
+
 export interface IMockedRequestResponse {
     id: string;
     newScenarioState?: string;
@@ -36,15 +38,19 @@ export interface IRequestMock {
     [key: string]: unknown;
 }
 
-export interface IResponseMock {
-    status: number;
-    headers?: Record<string, KeyValue>;
-    fixedDelayMilliseconds?: number;
-    delayDistribution?: Record<string, number | string>;
-    chunkedDribbleDelay?: Record<string, number>;
+export type IResponseMock =
+    | {
+          status: number;
+          headers?: Record<string, KeyValue>;
+          fixedDelayMilliseconds?: number;
+          delayDistribution?: Record<string, number | string>;
+          chunkedDribbleDelay?: Record<string, number>;
 
-    [key: string]: unknown;
-}
+          [key: string]: unknown;
+      }
+    | {
+          fault: WireMockFault;
+      };
 
 export interface IScenarioGetResponse {
     scenarios: Array<unknown>;

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -396,6 +396,7 @@ describe('Integration with WireMock', () => {
                 const data = response.data;
                 expect(statusCode).toEqual(200);
                 expect(data).toBeDefined();
+                expect(data).not.toEqual(responseBody);
             });
         });
 

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -375,6 +375,28 @@ describe('Integration with WireMock', () => {
                     'Parse Error: Expected HTTP/',
                 );
             });
+
+            it('sets up a stub mapping in wiremock server w/ MALFORMED_RESPONSE_CHUNK fault', async () => {
+                const testEndpoint = '/test-endpoint';
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {
+                        method: 'POST',
+                        endpoint: testEndpoint,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                    { fault: WireMockFault.MALFORMED_RESPONSE_CHUNK },
+                );
+
+                const response = await axios.post(wiremockUrl + testEndpoint);
+                const statusCode = response.status;
+                const data = response.data;
+                expect(statusCode).toEqual(200);
+                expect(data).toBeDefined();
+            });
         });
 
         describe('deleteMapping', () => {

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -336,7 +336,7 @@ describe('Integration with WireMock', () => {
                 );
             });
 
-            it('sets up a stub mapping in wiremock server w/ EMPTY_RESPONSE fault', async () => {
+            it('sets up a stub mapping in wiremock server w/ CONNECTION_RESET_BY_PEER fault', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
                 await mock.register(
@@ -348,7 +348,7 @@ describe('Integration with WireMock', () => {
                         status: 200,
                         body: responseBody,
                     },
-                    { fault: WireMockFault.EMPTY_RESPONSE },
+                    { fault: WireMockFault.CONNECTION_RESET_BY_PEER },
                 );
 
                 await expect(axios.post(wiremockUrl + testEndpoint)).rejects.toThrowError(

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -316,7 +316,7 @@ describe('Integration with WireMock', () => {
                 );
             });
 
-            it('sets up a stub mapping in wiremock server w/ fault', async () => {
+            it('sets up a stub mapping in wiremock server w/ EMPTY_RESPONSE fault', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
                 await mock.register(
@@ -333,6 +333,46 @@ describe('Integration with WireMock', () => {
 
                 await expect(axios.post(wiremockUrl + testEndpoint)).rejects.toThrowError(
                     'socket hang up',
+                );
+            });
+
+            it('sets up a stub mapping in wiremock server w/ EMPTY_RESPONSE fault', async () => {
+                const testEndpoint = '/test-endpoint';
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {
+                        method: 'POST',
+                        endpoint: testEndpoint,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                    { fault: WireMockFault.EMPTY_RESPONSE },
+                );
+
+                await expect(axios.post(wiremockUrl + testEndpoint)).rejects.toThrowError(
+                    'socket hang up',
+                );
+            });
+
+            it('sets up a stub mapping in wiremock server w/ RANDOM_DATA_THEN_CLOSE fault', async () => {
+                const testEndpoint = '/test-endpoint';
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {
+                        method: 'POST',
+                        endpoint: testEndpoint,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                    { fault: WireMockFault.RANDOM_DATA_THEN_CLOSE },
+                );
+
+                await expect(axios.post(wiremockUrl + testEndpoint)).rejects.toThrowError(
+                    'Parse Error: Expected HTTP/',
                 );
             });
         });

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 import * as express from 'express';
 import { Server } from 'http';
 
-import { DelayType, WireMock } from '../../src';
+import { DelayType, WireMock, WireMockFault } from '../../src';
 
 const WEBHOOK_BASE_URL: string = 'http://host.docker.internal';
 const WEBHOOK_PORT: number = 9876;
@@ -313,6 +313,26 @@ describe('Integration with WireMock', () => {
                 });
                 expect(jestMock).toHaveBeenCalledWith(
                     expect.objectContaining({ body: JSON.stringify(requestBody) }),
+                );
+            });
+
+            it('sets up a stub mapping in wiremock server w/ fault', async () => {
+                const testEndpoint = '/test-endpoint';
+                const responseBody = { test: 'testValue' };
+                await mock.register(
+                    {
+                        method: 'POST',
+                        endpoint: testEndpoint,
+                    },
+                    {
+                        status: 200,
+                        body: responseBody,
+                    },
+                    { fault: WireMockFault.EMPTY_RESPONSE },
+                );
+
+                await expect(axios.post(wiremockUrl + testEndpoint)).rejects.toThrowError(
+                    'socket hang up',
                 );
             });
         });

--- a/test/unit/WireMock.spec.ts
+++ b/test/unit/WireMock.spec.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import { DelayType } from '../../src';
+import { DelayType, WireMockFault } from '../../src';
 
 describe('WireMock', () => {
     const mockData = {
@@ -213,6 +213,32 @@ describe('WireMock', () => {
                 },
             );
             expect(resp).toEqual({});
+        });
+
+        it('should return empty response w/ fault', async () => {
+            jest.mock('../../src/RequestModel', () => ({
+                createWireMockRequest: jest.fn().mockName('mockedGetRequest'),
+            }));
+            jest.mock('../../src/ResponseModel', () => ({
+                createWireMockResponse: jest.fn().mockName('mockedGetResponse'),
+            }));
+            const wireMock = require('../../src/WireMock');
+            const wireMockUrl = 'https://testservice/';
+            const mock = new wireMock.WireMock(wireMockUrl);
+            const resp = await mock.register({}, {}, { fault: WireMockFault.EMPTY_RESPONSE });
+            expect(resp).toEqual({});
+            expect(mockAxios.default.post).toHaveBeenCalledWith(
+                'https://testservice/__admin/mappings',
+                {
+                    request: undefined,
+                    response: { fault: 'EMPTY_RESPONSE' },
+                },
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
         });
     });
 


### PR DESCRIPTION
### SUMMARY

Add support for wiremock response fault

### DETAILS

more info: https://wiremock.org/docs/simulating-faults/

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
