### PR TITLE
Configure jest to use axios commonjs file

### DIFF
--- a/examples/express-app/jest.config.js
+++ b/examples/express-app/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  moduleNameMapper: {
+    axios: 'axios/dist/node/axios.cjs',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testRegex: '(/test/integration/.*|(\\.|/)(test|spec))\\.(ts)x?$',
   coverageDirectory: 'coverage',


### PR DESCRIPTION
### SUMMARY
[Running the demo](https://github.com/HBOCodeLabs/wiremock-captain#running-the-demo) failed in the last step when it comes to `npm run test`. See [issue](https://github.com/HBOCodeLabs/wiremock-captain/issues/244)

### DETAILS
Mapped the module name `axios` to the commonJs file.

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
