### PR TITLE
feat: initialization feature parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wiremock-captain",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wiremock-captain",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-captain",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A better way to use the WireMock simulator to test your HTTP APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/RequestModel.ts
+++ b/src/RequestModel.ts
@@ -8,10 +8,10 @@ import { IWireMockRequest } from './types/IWireMockRequest';
 
 export function createWireMockRequest(
     request: IWireMockRequest,
-    features?: IWireMockFeatures,
+    features: IWireMockFeatures,
 ): IRequestMock {
     const { body, cookies, headers, method, queryParameters, endpoint, formParameters } = request;
-    const endpointFeature: string = features?.requestEndpointFeature ?? EndpointFeature.Default;
+    const endpointFeature: string = features.requestEndpointFeature ?? EndpointFeature.Default;
 
     const mock: IRequestMock = {
         method,
@@ -19,36 +19,33 @@ export function createWireMockRequest(
     mock[endpointFeature] = endpoint;
 
     if (body) {
-        const bodyFeature: string = features?.requestBodyFeature ?? MatchingAttributes.EqualToJson;
+        const bodyFeature: string = features.requestBodyFeature ?? MatchingAttributes.EqualToJson;
         const mockBody: { [key: string]: unknown } = {};
         mockBody[bodyFeature] = body;
 
         if (bodyFeature === MatchingAttributes.EqualToJson) {
-            mockBody['ignoreArrayOrder'] = features?.requestIgnoreArrayOrder ?? false;
-            mockBody['ignoreExtraElements'] = features?.requestIgnoreExtraElements ?? false;
+            mockBody['ignoreArrayOrder'] = features.requestIgnoreArrayOrder ?? false;
+            mockBody['ignoreExtraElements'] = features.requestIgnoreExtraElements ?? false;
         }
         mock.bodyPatterns = [mockBody];
     }
 
     if (cookies) {
-        mock.cookies = getMockedObject(cookies, features?.requestCookieFeatures);
+        mock.cookies = getMockedObject(cookies, features.requestCookieFeatures);
     }
 
     if (headers) {
-        mock.headers = getMockedObject(headers, features?.requestHeaderFeatures);
+        mock.headers = getMockedObject(headers, features.requestHeaderFeatures);
     }
 
     if (queryParameters) {
-        mock.queryParameters = getMockedObject(
-            queryParameters,
-            features?.requestQueryParamFeatures,
-        );
+        mock.queryParameters = getMockedObject(queryParameters, features.requestQueryParamFeatures);
     }
 
     if (formParameters) {
         mock.formParameters = getMockedObject(
             formParameters,
-            features?.requestFormParameterFeatures,
+            features.requestFormParameterFeatures,
         );
     }
 

--- a/src/ResponseModel.ts
+++ b/src/ResponseModel.ts
@@ -8,13 +8,13 @@ import { IWireMockResponse } from './types/IWireMockResponse';
 
 export function createWireMockResponse(
     response: IWireMockResponse,
-    features?: IWireMockFeatures,
+    features: IWireMockFeatures,
 ): IResponseMock {
     const { body, headers, status } = response;
     const mockedResponse: IResponseMock = {
         status,
     };
-    const bodyType: string = features?.responseBodyType ?? BodyType.Default;
+    const bodyType: string = features.responseBodyType ?? BodyType.Default;
 
     if (body) {
         mockedResponse[bodyType] = body;
@@ -27,7 +27,7 @@ export function createWireMockResponse(
         ...headers,
     };
 
-    const delay = features?.responseDelay;
+    const delay = features.responseDelay;
 
     switch (delay?.type) {
         case DelayType.CHUNKED_DRIBBLE:
@@ -56,7 +56,7 @@ export function createWireMockResponse(
         default:
     }
 
-    if (features?.responseTransformers && features.responseTransformers.length > 0) {
+    if (features.responseTransformers && features.responseTransformers.length > 0) {
         mockedResponse.transformers = features.responseTransformers;
     }
 

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -59,35 +59,37 @@ export class WireMock {
             response: mockedResponse,
         };
 
-        if (features?.stubPriority) {
-            mock.priority = features.stubPriority;
+        if (mergedFeatures?.stubPriority) {
+            mock.priority = mergedFeatures.stubPriority;
         }
 
-        if (features?.scenario) {
-            mock = { ...mock, ...features.scenario };
+        if (mergedFeatures?.scenario) {
+            mock = { ...mock, ...mergedFeatures.scenario };
         }
 
-        if (features?.webhook) {
+        if (mergedFeatures?.webhook) {
             mock.postServeActions = [
                 {
                     name: 'webhook',
                     parameters: {
-                        method: features.webhook.method,
-                        url: features.webhook.url,
-                        ...(features.webhook.headers && { headers: features.webhook.headers }),
-                        ...(features.webhook.body && {
-                            body: getWebhookBody(features.webhook.body),
+                        method: mergedFeatures.webhook.method,
+                        url: mergedFeatures.webhook.url,
+                        ...(mergedFeatures.webhook.headers && {
+                            headers: mergedFeatures.webhook.headers,
                         }),
-                        ...(features.webhook.delay && {
-                            delay: getWebhookDelayBody(features.webhook.delay),
+                        ...(mergedFeatures.webhook.body && {
+                            body: getWebhookBody(mergedFeatures.webhook.body),
+                        }),
+                        ...(mergedFeatures.webhook.delay && {
+                            delay: getWebhookDelayBody(mergedFeatures.webhook.delay),
                         }),
                     },
                 },
             ];
         }
 
-        if (features?.fault) {
-            mock.response = { fault: features.fault };
+        if (mergedFeatures?.fault) {
+            mock.response = { fault: mergedFeatures.fault };
         }
 
         const wiremockResponse = await axios.post(this.makeUrl(WIREMOCK_MAPPINGS_URL), mock, {

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -29,9 +29,14 @@ const HEADERS = { 'Content-Type': 'application/json' };
 
 export class WireMock {
     protected readonly baseUrl: string;
+    protected readonly features: IWireMockFeatures;
 
-    public constructor(baseUrl: string) {
+    public constructor(
+        baseUrl: string,
+        features?: Omit<IWireMockFeatures, 'scenario' | 'stubPriority'>,
+    ) {
         this.baseUrl = baseUrl;
+        this.features = features ?? {};
     }
 
     /**
@@ -46,8 +51,9 @@ export class WireMock {
         response: IWireMockResponse,
         features?: IWireMockFeatures,
     ): Promise<IMockedRequestResponse> {
-        const mockedRequest = createWireMockRequest(request, features);
-        const mockedResponse = createWireMockResponse(response, features);
+        const mergedFeatures = this.mergeWireMockFeatures(features);
+        const mockedRequest = createWireMockRequest(request, mergedFeatures);
+        const mockedResponse = createWireMockResponse(response, mergedFeatures);
         let mock: IMockType = {
             request: mockedRequest,
             response: mockedResponse,
@@ -208,5 +214,12 @@ export class WireMock {
 
     protected makeUrl(endpoint: string): string {
         return new URL(endpoint, this.baseUrl).href;
+    }
+
+    private mergeWireMockFeatures(features?: IWireMockFeatures): IWireMockFeatures {
+        return {
+            ...this.features, // Base features as default values
+            ...features, // Override with parameter values
+        };
     }
 }

--- a/src/WireMockAPI.ts
+++ b/src/WireMockAPI.ts
@@ -8,7 +8,7 @@ import { WireMock } from './WireMock';
 export class WireMockAPI extends WireMock {
     protected readonly endpoint: string;
     protected readonly method: Method;
-    protected readonly features: IWireMockFeatures | undefined;
+    override readonly features: IWireMockFeatures;
 
     public constructor(
         baseUrl: string,
@@ -19,7 +19,7 @@ export class WireMockAPI extends WireMock {
         super(baseUrl);
         this.endpoint = endpoint;
         this.method = method;
-        this.features = features;
+        this.features = features ?? {};
     }
 
     /**

--- a/test/unit/RequestModel.spec.ts
+++ b/test/unit/RequestModel.spec.ts
@@ -12,10 +12,13 @@ describe('RequestModel', () => {
     describe('createWireMockRequest', () => {
         test('builds with method and endpoint', () => {
             const testModule = require('../../src/RequestModel');
-            const mockedRequest = testModule.createWireMockRequest({
-                method: 'GET',
-                endpoint: '/test-endpoint',
-            });
+            const mockedRequest = testModule.createWireMockRequest(
+                {
+                    method: 'GET',
+                    endpoint: '/test-endpoint',
+                },
+                {},
+            );
             expect(mockedRequest).toEqual({
                 method: 'GET',
                 url: '/test-endpoint',
@@ -39,11 +42,14 @@ describe('RequestModel', () => {
 
         test('builds with method, endpoint, and body', () => {
             const testModule = require('../../src/RequestModel');
-            const mockedRequest = testModule.createWireMockRequest({
-                method: 'GET',
-                endpoint: '/test-endpoint',
-                body: { testKey: 'testValue' },
-            });
+            const mockedRequest = testModule.createWireMockRequest(
+                {
+                    method: 'GET',
+                    endpoint: '/test-endpoint',
+                    body: { testKey: 'testValue' },
+                },
+                {},
+            );
             expect(mockedRequest).toEqual({
                 method: 'GET',
                 url: '/test-endpoint',
@@ -76,11 +82,14 @@ describe('RequestModel', () => {
 
         test('builds with method, endpoint, and cookies', () => {
             const testModule = require('../../src/RequestModel');
-            const mockedRequest = testModule.createWireMockRequest({
-                method: 'GET',
-                endpoint: '/test-endpoint',
-                cookies: { profile: 'test-user' },
-            });
+            const mockedRequest = testModule.createWireMockRequest(
+                {
+                    method: 'GET',
+                    endpoint: '/test-endpoint',
+                    cookies: { profile: 'test-user' },
+                },
+                {},
+            );
             expect(mockedRequest).toEqual({
                 method: 'GET',
                 url: '/test-endpoint',
@@ -111,11 +120,14 @@ describe('RequestModel', () => {
 
         test('builds with method, endpoint, and headers', () => {
             const testModule = require('../../src/RequestModel');
-            const mockedRequest = testModule.createWireMockRequest({
-                method: 'GET',
-                endpoint: '/test-endpoint',
-                headers: { Accept: 'json' },
-            });
+            const mockedRequest = testModule.createWireMockRequest(
+                {
+                    method: 'GET',
+                    endpoint: '/test-endpoint',
+                    headers: { Accept: 'json' },
+                },
+                {},
+            );
             expect(mockedRequest).toEqual({
                 method: 'GET',
                 url: '/test-endpoint',
@@ -146,17 +158,20 @@ describe('RequestModel', () => {
 
         test('builds with method, endpoint, queryParams, and formParameters', () => {
             const testModule = require('../../src/RequestModel');
-            const mockedRequest = testModule.createWireMockRequest({
-                method: 'GET',
-                endpoint: '/test-endpoint',
-                queryParameters: {
-                    a: 'test-val',
-                    b: 1,
+            const mockedRequest = testModule.createWireMockRequest(
+                {
+                    method: 'GET',
+                    endpoint: '/test-endpoint',
+                    queryParameters: {
+                        a: 'test-val',
+                        b: 1,
+                    },
+                    formParameters: {
+                        c: true,
+                    },
                 },
-                formParameters: {
-                    c: true,
-                },
-            });
+                {},
+            );
             expect(mockedRequest).toEqual({
                 method: 'GET',
                 url: '/test-endpoint',

--- a/test/unit/ResponseModel.spec.ts
+++ b/test/unit/ResponseModel.spec.ts
@@ -12,9 +12,12 @@ describe('ResponseModel', () => {
     describe('createWireMockResponse', () => {
         test('builds with statusCode', () => {
             const testModule = require('../../src/ResponseModel');
-            const mockedResponse = testModule.createWireMockResponse({
-                status: 200,
-            });
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                },
+                {},
+            );
             expect(mockedResponse).toEqual({
                 status: 200,
                 headers: { 'Content-Type': 'application/json; charset=utf-8' },
@@ -23,10 +26,13 @@ describe('ResponseModel', () => {
 
         test('builds with statusCode and body', () => {
             const testModule = require('../../src/ResponseModel');
-            const mockedResponse = testModule.createWireMockResponse({
-                status: 200,
-                body: { testKey: 'test-value' },
-            });
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                    body: { testKey: 'test-value' },
+                },
+                {},
+            );
             expect(mockedResponse).toEqual({
                 status: 200,
                 headers: { 'Content-Type': 'application/json; charset=utf-8' },
@@ -52,10 +58,13 @@ describe('ResponseModel', () => {
 
         test('builds with statusCode and headers', () => {
             const testModule = require('../../src/ResponseModel');
-            const mockedResponse = testModule.createWireMockResponse({
-                status: 200,
-                headers: { Accept: 'json' },
-            });
+            const mockedResponse = testModule.createWireMockResponse(
+                {
+                    status: 200,
+                    headers: { Accept: 'json' },
+                },
+                {},
+            );
             expect(mockedResponse).toEqual({
                 status: 200,
                 headers: { Accept: 'json', 'Content-Type': 'application/json; charset=utf-8' },


### PR DESCRIPTION
### SUMMARY

Allow assigning features when instantiating wiremock instance

closes #629 

### DETAILS

Pass in constructor param if required

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
