### PR TITLE
fix: Configure jest to use commonjs-compatible version of axios in demo app

### DIFF
--- a/examples/express-app/jest.config.js
+++ b/examples/express-app/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    axios: 'axios/dist/node/axios.cjs',
+  },
   testRegex: '(/test/integration/.*|(\\.|/)(test|spec))\\.(ts)x?$',
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}', '!src/**/*.d.ts'],


### PR DESCRIPTION
### SUMMARY

Fixes an error that occurs when running `npm run test` as described in the "Running the demo" section of the README.md file. Looks like an issue for it was already filed a while back, but the fix wasn't merged. [issue](https://github.com/HBOCodeLabs/wiremock-captain/issues/244)

### DETAILS

Configured jest in the example express-app to use the commonjs-compatible version of axios

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
