### PR TITLE
feat: native fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
   <p />
 </div>
 
-[![npm](https://img.shields.io/npm/v/wiremock-captain)](https://www.npmjs.com/package/wiremock-captain)
-[![npm](https://img.shields.io/npm/dw/wiremock-captain)](https://www.npmjs.com/package/wiremock-captain)
+[![npm version](https://img.shields.io/npm/v/wiremock-captain)](https://www.npmjs.com/package/wiremock-captain)
+![npm bundle size](https://img.shields.io/bundlephobia/min/wiremock-captain)
+[![npm downloads](https://img.shields.io/npm/dw/wiremock-captain)](https://www.npmjs.com/package/wiremock-captain)
 [![Azure DevOps builds](https://img.shields.io/azure-devops/build/HBODigitalProducts/e6cee603-ddc7-43e3-b1a8-e2d6b3f6173c/37)](https://dev.azure.com/HBODigitalProducts/OSS/_build?definitionId=37&branchFilter=1388%2C1388%2C1388%2C1388%2C1388%2C1388%2C1388%2C1388)
 [![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/HBODigitalProducts/OSS/37)](https://dev.azure.com/HBODigitalProducts/OSS/_build?definitionId=37&branchFilter=1388%2C1388%2C1388%2C1388%2C1388%2C1388%2C1388%2C1388)
 [![node-current](https://img.shields.io/node/v/wiremock-captain)](https://www.npmjs.com/package/wiremock-captain)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,19 @@
 {
   "name": "wiremock-captain",
-  "version": "3.6.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wiremock-captain",
-      "version": "3.6.1",
+      "version": "4.0.0",
       "license": "MIT",
-      "dependencies": {
-        "axios": "1.8.2"
-      },
       "devDependencies": {
         "@eslint/js": "9.21.0",
         "@types/express": "5.0.0",
         "@types/jest": "29.5.14",
         "@types/node": "^22",
+        "axios": "1.8.3",
         "eslint": "9.21.0",
         "eslint-config-prettier": "10.1.1",
         "eslint-plugin-prettier": "5.2.3",
@@ -78,22 +76,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -108,25 +106,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -150,16 +138,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -235,27 +213,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -519,17 +497,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -548,9 +526,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -569,9 +547,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -585,6 +563,19 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint-community/regexpp": {
@@ -610,30 +601,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@eslint/core": {
@@ -673,17 +640,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -695,19 +651,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -1622,9 +1565,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1830,6 +1773,45 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
@@ -1870,19 +1852,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/accepts": {
@@ -2020,12 +1989,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -2087,16 +2058,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
@@ -2209,13 +2170,14 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -2308,6 +2270,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2355,9 +2318,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001702",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
-      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
+      "version": "1.0.30001704",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
+      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
       "dev": true,
       "funding": [
         {
@@ -2482,6 +2445,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2658,6 +2622,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2708,6 +2673,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2749,9 +2715,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.113",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz",
-      "integrity": "sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==",
+      "version": "1.5.116",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.116.tgz",
+      "integrity": "sha512-mufxTCJzLBQVvSdZzX1s5YAuXsN1M4tTyYxOOL1TcSKtIzQ9rjIrm7yFK80rN5dwGTePgdoABDSHpuVtRQh0Zw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2799,6 +2765,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2808,6 +2775,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2817,6 +2785,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2829,6 +2798,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2975,9 +2945,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2992,30 +2962,6 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
@@ -3026,19 +2972,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -3052,19 +2985,6 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3357,6 +3277,16 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -3461,6 +3391,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3511,6 +3442,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3568,6 +3500,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3597,6 +3530,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3631,6 +3565,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3688,30 +3623,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/globals": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
@@ -3729,6 +3640,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3765,6 +3677,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3777,6 +3690,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3792,6 +3706,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4022,6 +3937,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4051,6 +3973,19 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4133,30 +4068,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -4657,6 +4568,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -4939,6 +4863,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -4960,6 +4897,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5043,6 +4981,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5052,6 +4991,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5071,19 +5011,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/minipass": {
@@ -5768,6 +5705,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pseudomap": {
@@ -5890,13 +5828,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6009,6 +5940,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
@@ -6102,16 +6043,13 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -6565,30 +6503,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -6686,6 +6600,19 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HBOCodeLabs/wiremock-captain.git"
+    "url": "git+https://github.com/HBOCodeLabs/wiremock-captain.git"
   },
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-captain",
-  "version": "3.6.1",
+  "version": "4.0.0",
   "description": "A better way to use the WireMock simulator to test your HTTP APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,14 +39,12 @@
     "node": ">=22.14.0",
     "npm": ">=10.9.2"
   },
-  "dependencies": {
-    "axios": "1.8.2"
-  },
   "devDependencies": {
     "@eslint/js": "9.21.0",
     "@types/express": "5.0.0",
     "@types/jest": "29.5.14",
     "@types/node": "^22",
+    "axios": "1.8.3",
     "eslint": "9.21.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-prettier": "5.2.3",

--- a/src/WireMock.ts
+++ b/src/WireMock.ts
@@ -117,11 +117,9 @@ export class WireMock {
      * Removes all existing stubs
      */
     public async clearAllMappings(): Promise<Response> {
-        const response = await fetch(this.makeUrl(WIREMOCK_MAPPINGS_URL), {
+        return await fetch(this.makeUrl(WIREMOCK_MAPPINGS_URL), {
             method: 'DELETE',
         });
-
-        return response;
     }
 
     /**
@@ -164,7 +162,7 @@ export class WireMock {
      * @returns List of all requests made to the mocked instance
      */
     public async getAllRequests(): Promise<unknown[]> {
-        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL));
+        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL), { method: 'GET' });
         const responseJson: IRequestGetResponse = (await response.json()) as IRequestGetResponse;
         return responseJson.requests;
     }
@@ -173,7 +171,7 @@ export class WireMock {
      * @returns List of all scenarios in place for the mocked instance
      */
     public async getAllScenarios(): Promise<unknown[]> {
-        const response = await fetch(this.makeUrl(WIREMOCK_SCENARIO_URL));
+        const response = await fetch(this.makeUrl(WIREMOCK_SCENARIO_URL), { method: 'GET' });
         const responseJson: IScenarioGetResponse = (await response.json()) as IScenarioGetResponse;
         return responseJson.scenarios;
     }
@@ -184,9 +182,10 @@ export class WireMock {
      * @returns Single object mapping corresponding to the input `id`
      */
     public async getMapping(id: string): Promise<unknown> {
-        const response = await fetch(this.makeUrl(`${WIREMOCK_MAPPINGS_URL}/${id}`));
-        const responseData = await response.json();
-        return responseData;
+        const response = await fetch(this.makeUrl(`${WIREMOCK_MAPPINGS_URL}/${id}`), {
+            method: 'GET',
+        });
+        return await response.json();
     }
 
     /**
@@ -196,7 +195,7 @@ export class WireMock {
      * @returns List of wiremock requests made to the endpoint with given method
      */
     public async getRequestsForAPI(method: Method, endpointUrl: string): Promise<unknown[]> {
-        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL));
+        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL), { method: 'GET' });
         const body: IRequestGetResponse = (await response.json()) as IRequestGetResponse;
         return (
             body.requests
@@ -210,7 +209,9 @@ export class WireMock {
      * @returns List of wiremock requests made that did not match any mapping
      */
     public async getUnmatchedRequests(): Promise<unknown[]> {
-        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL + '/unmatched'));
+        const response = await fetch(this.makeUrl(WIREMOCK_REQUESTS_URL + '/unmatched'), {
+            method: 'GET',
+        });
         const body: IRequestGetResponse = (await response.json()) as IRequestGetResponse;
         return body.requests;
     }

--- a/test/integration/WireMock.spec.ts
+++ b/test/integration/WireMock.spec.ts
@@ -12,7 +12,7 @@ const WEBHOOK_PORT = 9876;
 
 describe('Integration with WireMock', () => {
     const wiremockUrl = 'http://localhost:8080';
-    const mock = new WireMock(wiremockUrl);
+    const wireMock = new WireMock(wiremockUrl);
     let webhookPromiseResolve: (r: jest.Mock) => void;
     let webhookPromise: Promise<jest.Mock>;
     let server: Server;
@@ -43,11 +43,12 @@ describe('Integration with WireMock', () => {
     });
 
     beforeEach(async () => {
-        await mock.clearAllExceptDefault();
+        await wireMock.clearAllExceptDefault();
     });
 
     afterAll(() => {
-        mock.clearAll()
+        wireMock
+            .clearAll()
             .then(() => {
                 server.close().on('error', (e) => {
                     throw new Error('Error closing webhook callback server: ' + e.message);
@@ -69,7 +70,7 @@ describe('Integration with WireMock', () => {
                 };
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -86,7 +87,7 @@ describe('Integration with WireMock', () => {
                 const body = response.data;
                 expect(body).toEqual(responseBody);
                 expect(Date.now() - start).toBeLessThan(300);
-                const calls = await mock.getRequestsForAPI('POST', testEndpoint);
+                const calls = await wireMock.getRequestsForAPI('POST', testEndpoint);
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,7 +101,7 @@ describe('Integration with WireMock', () => {
 
             test('sets up a stub mapping with response templating and expects response to have request path', async () => {
                 const testEndpoint = '/test-endpoint';
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'GET',
                         endpoint: '/test-endpoint',
@@ -128,7 +129,7 @@ describe('Integration with WireMock', () => {
                 };
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -156,7 +157,7 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping in wiremock server without body', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -175,7 +176,7 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping in wiremock server w/ array order ignored', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -202,7 +203,7 @@ describe('Integration with WireMock', () => {
                 const timestamp = Date.now();
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -238,7 +239,7 @@ describe('Integration with WireMock', () => {
                 const timestamp = Date.now();
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -279,7 +280,7 @@ describe('Integration with WireMock', () => {
                 };
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                const mockedStub = await mock.register(
+                const mockedStub = await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -295,7 +296,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                const calls = await mock.getRequestsForAPI('POST', testEndpoint);
+                const calls = await wireMock.getRequestsForAPI('POST', testEndpoint);
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -317,7 +318,7 @@ describe('Integration with WireMock', () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBodyLowPriority = { test: 'testValue' };
                 const responseBodyHighPriority = { test: 'biggerTestValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -329,7 +330,7 @@ describe('Integration with WireMock', () => {
                     },
                     { stubPriority: 1 },
                 );
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -344,7 +345,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBodyHighPriority);
-                const calls = await mock.getRequestsForAPI('POST', testEndpoint);
+                const calls = await wireMock.getRequestsForAPI('POST', testEndpoint);
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -359,7 +360,7 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping in wiremock server w/ EMPTY_RESPONSE fault', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -379,7 +380,7 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping in wiremock server w/ CONNECTION_RESET_BY_PEER fault', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -399,7 +400,7 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping in wiremock server w/ RANDOM_DATA_THEN_CLOSE fault', async () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -422,8 +423,8 @@ describe('Integration with WireMock', () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
 
-                expect(await mock.getAllMappings()).toHaveLength(0);
-                const { id } = await mock.register(
+                expect(await wireMock.getAllMappings()).toHaveLength(0);
+                const { id } = await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -433,9 +434,9 @@ describe('Integration with WireMock', () => {
                         body: responseBody,
                     },
                 );
-                expect(await mock.getAllMappings()).toHaveLength(1);
-                await mock.deleteMapping(id);
-                expect(await mock.getAllMappings()).toHaveLength(0);
+                expect(await wireMock.getAllMappings()).toHaveLength(1);
+                await wireMock.deleteMapping(id);
+                expect(await wireMock.getAllMappings()).toHaveLength(0);
             });
         });
 
@@ -444,8 +445,8 @@ describe('Integration with WireMock', () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
 
-                expect(await mock.getAllMappings()).toHaveLength(0);
-                await mock.register(
+                expect(await wireMock.getAllMappings()).toHaveLength(0);
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -455,24 +456,24 @@ describe('Integration with WireMock', () => {
                         body: responseBody,
                     },
                 );
-                expect(await mock.getAllMappings()).toHaveLength(1);
+                expect(await wireMock.getAllMappings()).toHaveLength(1);
             });
         });
 
         describe('getRequests', () => {
             test('returns number of requests made', async () => {
                 const testEndpoint = '/test-endpoint';
-                await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
+                await wireMock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
                     await axios.get(wiremockUrl + testEndpoint);
                 }
-                expect(await mock.getAllRequests()).toHaveLength(5);
+                expect(await wireMock.getAllRequests()).toHaveLength(5);
             });
 
             test('returns number of unmatched requests', async () => {
                 const testEndpoint = '/test-endpoint';
-                await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
+                await wireMock.register({ method: 'GET', endpoint: testEndpoint }, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
                     try {
@@ -482,17 +483,17 @@ describe('Integration with WireMock', () => {
                         // empty
                     }
                 }
-                expect(await mock.getUnmatchedRequests()).toHaveLength(5);
+                expect(await wireMock.getUnmatchedRequests()).toHaveLength(5);
             });
         });
 
         describe('getScenarios', () => {
             test('should return scenarios', async () => {
                 const testEndpoint = '/test-endpoint';
-                expect(await mock.getAllScenarios()).toHaveLength(0);
-                await mock.register({ method: 'GET', endpoint: testEndpoint }, { status: 400 });
-                expect(await mock.getAllScenarios()).toHaveLength(0);
-                await mock.register(
+                expect(await wireMock.getAllScenarios()).toHaveLength(0);
+                await wireMock.register({ method: 'GET', endpoint: testEndpoint }, { status: 400 });
+                expect(await wireMock.getAllScenarios()).toHaveLength(0);
+                await wireMock.register(
                     { method: 'GET', endpoint: testEndpoint },
                     { status: 200 },
                     {
@@ -502,7 +503,7 @@ describe('Integration with WireMock', () => {
                         },
                     },
                 );
-                expect(await mock.getAllScenarios()).toHaveLength(1);
+                expect(await wireMock.getAllScenarios()).toHaveLength(1);
             });
         });
 
@@ -511,8 +512,8 @@ describe('Integration with WireMock', () => {
                 const testEndpoint = '/test-endpoint';
                 const responseBody = { test: 'testValue' };
 
-                expect(await mock.getAllMappings()).toHaveLength(0);
-                await mock.register(
+                expect(await wireMock.getAllMappings()).toHaveLength(0);
+                await wireMock.register(
                     {
                         method: 'POST',
                         endpoint: testEndpoint,
@@ -522,16 +523,16 @@ describe('Integration with WireMock', () => {
                         body: responseBody,
                     },
                 );
-                expect(await mock.getAllMappings()).toHaveLength(1);
-                await mock.resetMappings();
-                expect(await mock.getAllMappings()).toHaveLength(0);
+                expect(await wireMock.getAllMappings()).toHaveLength(1);
+                await wireMock.resetMappings();
+                expect(await wireMock.getAllMappings()).toHaveLength(0);
             });
         });
 
         describe('resetScenarios', () => {
             test('should return scenarios', async () => {
                 const testEndpoint = '/test-endpoint';
-                await mock.register(
+                await wireMock.register(
                     { method: 'GET', endpoint: testEndpoint },
                     { status: 200 },
                     {
@@ -542,7 +543,7 @@ describe('Integration with WireMock', () => {
                         },
                     },
                 );
-                await mock.register(
+                await wireMock.register(
                     { method: 'GET', endpoint: testEndpoint },
                     { status: 201 },
                     {
@@ -554,16 +555,16 @@ describe('Integration with WireMock', () => {
                 );
 
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+                expect((await wireMock.getAllScenarios())[0].state).toEqual('Started');
                 let resp = await axios.get(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(200);
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('test-state');
+                expect((await wireMock.getAllScenarios())[0].state).toEqual('test-state');
                 resp = await axios.get(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(201);
-                await mock.resetAllScenarios();
+                await wireMock.resetAllScenarios();
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+                expect((await wireMock.getAllScenarios())[0].state).toEqual('Started');
             });
         });
     });

--- a/test/integration/WireMockAPI.spec.ts
+++ b/test/integration/WireMockAPI.spec.ts
@@ -9,10 +9,10 @@ describe('Integration with WireMock', () => {
     const wiremockUrl = 'http://localhost:8080';
     const testEndpoint = '/test-endpoint';
     const testMethod = 'POST';
-    const mock = new WireMockAPI(wiremockUrl, testEndpoint, testMethod);
+    const wireMockAPI = new WireMockAPI(wiremockUrl, testEndpoint, testMethod);
 
     beforeEach(async () => {
-        await mock.clearAllExceptDefault();
+        await wireMockAPI.clearAllExceptDefault();
     });
 
     describe('WireMockAPI', () => {
@@ -25,7 +25,7 @@ describe('Integration with WireMock', () => {
                     },
                 };
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMockAPI.register(
                     {
                         body: requestBody,
                     },
@@ -38,7 +38,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                const calls = await mock.getRequestsForAPI();
+                const calls = await wireMockAPI.getRequestsForAPI();
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,7 +52,7 @@ describe('Integration with WireMock', () => {
 
             test('sets up a stub mapping in wiremock server without body', async () => {
                 const responseBody = { test: 'testValue' };
-                await mock.register(
+                await wireMockAPI.register(
                     {},
                     {
                         status: 200,
@@ -63,7 +63,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                await mock.getRequestsForAPI();
+                await wireMockAPI.getRequestsForAPI();
             });
 
             test('sets up a stub mapping in wiremock server with priority', async () => {
@@ -74,7 +74,7 @@ describe('Integration with WireMock', () => {
                     },
                 };
                 const responseBody = { test: 'testValue' };
-                const mockedStub = await mock.register(
+                const mockedStub = await wireMockAPI.register(
                     {
                         body: requestBody,
                     },
@@ -88,7 +88,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBody);
-                const calls = await mock.getRequestsForAPI();
+                const calls = await wireMockAPI.getRequestsForAPI();
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -109,7 +109,7 @@ describe('Integration with WireMock', () => {
                 };
                 const responseBodyLowPriority = { test: 'testValue' };
                 const responseBodyHighPriority = { test: 'biggerTestValue' };
-                await mock.register(
+                await wireMockAPI.register(
                     {
                         body: requestBody,
                     },
@@ -119,7 +119,7 @@ describe('Integration with WireMock', () => {
                     },
                     { stubPriority: 1 },
                 );
-                await mock.register(
+                await wireMockAPI.register(
                     {
                         body: requestBody,
                     },
@@ -132,7 +132,7 @@ describe('Integration with WireMock', () => {
                 const response = await axios.post(wiremockUrl + testEndpoint, requestBody);
                 const body = response.data;
                 expect(body).toEqual(responseBodyHighPriority);
-                const calls = await mock.getRequestsForAPI();
+                const calls = await wireMockAPI.getRequestsForAPI();
 
                 const jestMock = jest.fn();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -149,17 +149,17 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping and deletes it', async () => {
                 const responseBody = { test: 'testValue' };
 
-                expect(await mock.getAllMappings()).toHaveLength(0);
-                const { id } = await mock.register(
+                expect(await wireMockAPI.getAllMappings()).toHaveLength(0);
+                const { id } = await wireMockAPI.register(
                     {},
                     {
                         status: 200,
                         body: responseBody,
                     },
                 );
-                expect(await mock.getAllMappings()).toHaveLength(1);
-                await mock.deleteMapping(id);
-                expect(await mock.getAllMappings()).toHaveLength(0);
+                expect(await wireMockAPI.getAllMappings()).toHaveLength(1);
+                await wireMockAPI.deleteMapping(id);
+                expect(await wireMockAPI.getAllMappings()).toHaveLength(0);
             });
         });
 
@@ -167,21 +167,21 @@ describe('Integration with WireMock', () => {
             test('sets up a stub mapping and returns it with get mappings', async () => {
                 const responseBody = { test: 'testValue' };
 
-                expect(await mock.getAllMappings()).toHaveLength(0);
-                await mock.register(
+                expect(await wireMockAPI.getAllMappings()).toHaveLength(0);
+                await wireMockAPI.register(
                     {},
                     {
                         status: 200,
                         body: responseBody,
                     },
                 );
-                expect(await mock.getAllMappings()).toHaveLength(1);
+                expect(await wireMockAPI.getAllMappings()).toHaveLength(1);
             });
         });
 
         describe('getRequests', () => {
             test('returns number of unmatched requests', async () => {
-                await mock.register({}, { status: 200 });
+                await wireMockAPI.register({}, { status: 200 });
 
                 for (let i = 0; i < 5; i++) {
                     try {
@@ -191,16 +191,16 @@ describe('Integration with WireMock', () => {
                         /* empty */
                     }
                 }
-                expect(await mock.getUnmatchedRequests()).toHaveLength(5);
+                expect(await wireMockAPI.getUnmatchedRequests()).toHaveLength(5);
             });
         });
 
         describe('getScenarios', () => {
             test('should return scenarios', async () => {
-                expect(await mock.getAllScenarios()).toHaveLength(0);
-                await mock.register({}, { status: 400 });
-                expect(await mock.getAllScenarios()).toHaveLength(0);
-                await mock.register(
+                expect(await wireMockAPI.getAllScenarios()).toHaveLength(0);
+                await wireMockAPI.register({}, { status: 400 });
+                expect(await wireMockAPI.getAllScenarios()).toHaveLength(0);
+                await wireMockAPI.register(
                     {},
                     { status: 200 },
                     {
@@ -210,13 +210,13 @@ describe('Integration with WireMock', () => {
                         },
                     },
                 );
-                expect(await mock.getAllScenarios()).toHaveLength(1);
+                expect(await wireMockAPI.getAllScenarios()).toHaveLength(1);
             });
         });
 
         describe('resetScenarios', () => {
             test('should return scenarios', async () => {
-                await mock.register(
+                await wireMockAPI.register(
                     {},
                     { status: 200 },
                     {
@@ -227,7 +227,7 @@ describe('Integration with WireMock', () => {
                         },
                     },
                 );
-                await mock.register(
+                await wireMockAPI.register(
                     {},
                     { status: 201 },
                     {
@@ -239,16 +239,16 @@ describe('Integration with WireMock', () => {
                 );
 
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+                expect((await wireMockAPI.getAllScenarios())[0].state).toEqual('Started');
                 let resp = await axios.post(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(200);
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('test-state');
+                expect((await wireMockAPI.getAllScenarios())[0].state).toEqual('test-state');
                 resp = await axios.post(wiremockUrl + testEndpoint);
                 expect(resp.status).toEqual(201);
-                await mock.resetAllScenarios();
+                await wireMockAPI.resetAllScenarios();
                 // @ts-expect-error known skip
-                expect((await mock.getAllScenarios())[0].state).toEqual('Started');
+                expect((await wireMockAPI.getAllScenarios())[0].state).toEqual('Started');
             });
         });
     });


### PR DESCRIPTION
### SUMMARY

use native `fetch` instead of `axios`

go from `1` to `0` core dependencies  🎉 

### DETAILS

- replace axios with fetch
- update tests
- breaking version change
- make axios dev dep to avoid refactoring all integration tests

### CHECKLIST
- [ ] Documentation updated (if needed)
- [ ] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
